### PR TITLE
Add NNTP parser using nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,30 @@
 version = 4
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "renews"
 version = "0.1.0"
+dependencies = [
+ "nom",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+nom = "7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,128 @@
+use nom::{
+    bytes::complete::{is_not, take_till, take_while1},
+    character::complete::{char, crlf, digit1, space0, space1},
+    combinator::{map_res, opt},
+    multi::separated_list1,
+    sequence::{preceded, tuple},
+};
+use nom::IResult;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Command {
+    pub name: String,
+    pub args: Vec<String>,
+}
+
+pub fn parse_command(input: &str) -> IResult<&str, Command> {
+    let (input, name) = take_while1(|c: char| c.is_ascii_alphabetic())(input)?;
+    let (input, args) = opt(preceded(space1, separated_list1(space1, is_not(" \r\n"))))(input)?;
+    let (input, _) = opt(crlf)(input)?;
+    let args_vec = args
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s: &str| s.to_string())
+        .collect();
+    Ok((input, Command { name: name.to_string(), args: args_vec }))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Response {
+    pub code: u16,
+    pub text: String,
+}
+
+pub fn parse_response(input: &str) -> IResult<&str, Response> {
+    let parse_code = map_res(digit1, |d: &str| d.parse::<u16>());
+    let (input, (code, text)) = tuple((parse_code, opt(preceded(char(' '), take_till(|c| c == '\r' || c == '\n')))))(input)?;
+    let (input, _) = opt(crlf)(input)?;
+    Ok((input, Response { code, text: text.unwrap_or("").to_string() }))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Message {
+    pub headers: Vec<(String, String)>,
+    pub body: String,
+}
+
+fn parse_header_line(input: &str) -> IResult<&str, (String, String)> {
+    let (input, name) = take_while1(|c: char| c != ':' && c != '\r' && c != '\n')(input)?;
+    let (input, _) = char(':')(input)?;
+    let (input, _) = space0(input)?;
+    let (input, value) = take_till(|c| c == '\r' || c == '\n')(input)?;
+    let (input, _) = crlf(input)?;
+    Ok((input, (name.to_string(), value.to_string())))
+}
+
+fn parse_headers(mut input: &str) -> IResult<&str, Vec<(String, String)>> {
+    let mut headers = Vec::new();
+    loop {
+        if let Some(rest) = input.strip_prefix("\r\n") {
+            input = rest;
+            break;
+        }
+        let (next, header) = parse_header_line(input)?;
+        headers.push(header);
+        input = next;
+    }
+    Ok((input, headers))
+}
+
+pub fn parse_message(input: &str) -> IResult<&str, Message> {
+    let (input, headers) = parse_headers(input)?;
+    let body = input.to_string();
+    Ok(("", Message { headers, body }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_command_simple() {
+        let (_, cmd) = parse_command("ARTICLE\r\n").unwrap();
+        assert_eq!(cmd.name, "ARTICLE");
+        assert!(cmd.args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_command_args() {
+        let (_, cmd) = parse_command("GROUP comp.lang.rust\r\n").unwrap();
+        assert_eq!(cmd.name, "GROUP");
+        assert_eq!(cmd.args, vec!["comp.lang.rust"]);
+    }
+
+    #[test]
+    fn test_parse_response() {
+        let (_, resp) = parse_response("211 123 group selected\r\n").unwrap();
+        assert_eq!(resp.code, 211);
+        assert_eq!(resp.text, "123 group selected");
+    }
+
+    #[test]
+    fn test_parse_response_no_text() {
+        let (_, resp) = parse_response("200\r\n").unwrap();
+        assert_eq!(resp.code, 200);
+        assert_eq!(resp.text, "");
+    }
+
+    #[test]
+    fn test_parse_message() {
+        let input = "Subject: Test\r\nFrom: user@example.com\r\n\r\nThis is the body.";
+        let (_, msg) = parse_message(input).unwrap();
+        assert_eq!(msg.headers.len(), 2);
+        assert_eq!(msg.headers[0], ("Subject".into(), "Test".into()));
+        assert_eq!(msg.headers[1], ("From".into(), "user@example.com".into()));
+        assert_eq!(msg.body, "This is the body.");
+    }
+
+    #[test]
+    fn test_post_command_with_message() {
+        let input = "POST\r\nSubject: Example\r\n\r\nBody text";
+        let (rest, cmd) = parse_command(input).unwrap();
+        assert_eq!(cmd.name, "POST");
+        assert!(cmd.args.is_empty());
+        let (_, msg) = parse_message(rest).unwrap();
+        assert_eq!(msg.headers, vec![("Subject".into(), "Example".into())]);
+        assert_eq!(msg.body, "Body text");
+    }
+}


### PR DESCRIPTION
## Summary
- add nom dependency
- implement basic NNTP command and response parsers in `lib.rs`
- support responses without trailing text
- implement message parser and tests
- add test to parse POST command followed by message

## Testing
- `cargo test --color never`


------
https://chatgpt.com/codex/tasks/task_e_685ff360864c8326bb8a4efacff0910f