### PR TITLE
Add code coverage to GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,9 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info    
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v4
         with:


### PR DESCRIPTION
## Summary
- run `cargo llvm-cov` in CI to gather coverage
- upload the `lcov.info` artifact
- move test and coverage steps to separate `test` job

## Testing
- `cargo test`
- `cargo install cargo-llvm-cov` *(succeeds)*
- `cargo llvm-cov --workspace --lcov --output-path lcov.info` *(fails: requires interactive confirmation)*

------
https://chatgpt.com/codex/tasks/task_e_685ff6e096f48326bd8936875426dde5