### PR TITLE
Add timestamp tracking and refine NEWNEWS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +156,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -476,6 +515,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +660,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -941,6 +1014,7 @@ name = "renews"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "nom",
  "serde",
  "serde_json",
@@ -1030,6 +1104,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1673,6 +1753,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1824,65 @@ checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
  "redox_syscall",
  "wasite",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ async-trait = "0.1"
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,601 @@ pub fn parse_message(input: &str) -> IResult<&str, Message> {
 pub mod storage;
 pub mod wildmat;
 
+use std::error::Error;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use crate::storage::DynStorage;
+
+async fn send_headers<W: AsyncWrite + Unpin>(writer: &mut W, article: &Message) -> Result<(), Box<dyn Error + Send + Sync>> {
+    for (k, v) in article.headers.iter() {
+        writer
+            .write_all(format!("{}: {}\r\n", k, v).as_bytes())
+            .await?;
+    }
+    Ok(())
+}
+
+async fn handle_quit<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<bool, Box<dyn Error + Send + Sync>> {
+    writer.write_all(b"205 closing connection\r\n").await?;
+    Ok(true)
+}
+
+async fn handle_group<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    args: &[String],
+    current_group: &mut String,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(name) = args.get(0) {
+        *current_group = name.clone();
+        writer
+            .write_all(format!("211 0 1 1 {}\r\n", name).as_bytes())
+            .await?;
+    } else {
+        writer.write_all(b"411 missing group\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_article<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    current_group: &str,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(arg) = args.get(0) {
+        if arg.starts_with('<') && arg.ends_with('>') {
+            if let Some(article) = storage.get_article_by_id(arg).await? {
+                writer.write_all(b"220 0 article follows\r\n").await?;
+                send_headers(writer, &article).await?;
+                writer.write_all(b"\r\n").await?;
+                writer.write_all(article.body.as_bytes()).await?;
+                writer.write_all(b"\r\n.\r\n").await?;
+            } else {
+                writer.write_all(b"430 no such article\r\n").await?;
+            }
+        } else if let Ok(num) = arg.parse::<u64>() {
+            if let Some(article) = storage.get_article_by_number(current_group, num).await? {
+                writer.write_all(b"220 0 article follows\r\n").await?;
+                send_headers(writer, &article).await?;
+                writer.write_all(b"\r\n").await?;
+                writer.write_all(article.body.as_bytes()).await?;
+                writer.write_all(b"\r\n.\r\n").await?;
+            } else {
+                writer
+                    .write_all(b"423 no such article number in this group\r\n")
+                    .await?;
+            }
+        } else {
+            writer.write_all(b"501 invalid id\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"501 missing id\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_head<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    current_group: &str,
+    current_article: &mut Option<u64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(arg) = args.get(0) {
+        if arg.starts_with('<') && arg.ends_with('>') {
+            if let Some(article) = storage.get_article_by_id(arg).await? {
+                writer.write_all(b"221 0 article headers follow\r\n").await?;
+                send_headers(writer, &article).await?;
+                writer.write_all(b".\r\n").await?;
+            } else {
+                writer.write_all(b"430 no such article\r\n").await?;
+            }
+        } else if let Ok(num) = arg.parse::<u64>() {
+            if let Some(article) = storage.get_article_by_number(current_group, num).await? {
+                *current_article = Some(num);
+                writer.write_all(b"221 0 article headers follow\r\n").await?;
+                send_headers(writer, &article).await?;
+                writer.write_all(b".\r\n").await?;
+            } else {
+                writer
+                    .write_all(b"423 no such article number in this group\r\n")
+                    .await?;
+            }
+        } else {
+            writer.write_all(b"501 invalid id\r\n").await?;
+        }
+    } else if let Some(num) = *current_article {
+        if let Some(article) = storage.get_article_by_number(current_group, num).await? {
+            writer.write_all(b"221 0 article headers follow\r\n").await?;
+            send_headers(writer, &article).await?;
+            writer.write_all(b".\r\n").await?;
+        } else {
+            writer.write_all(b"420 no current article selected\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"420 no current article selected\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_body<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    current_group: &str,
+    current_article: &mut Option<u64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(arg) = args.get(0) {
+        if arg.starts_with('<') && arg.ends_with('>') {
+            if let Some(article) = storage.get_article_by_id(arg).await? {
+                writer.write_all(b"222 0 article body follows\r\n").await?;
+                writer.write_all(article.body.as_bytes()).await?;
+                writer.write_all(b"\r\n.\r\n").await?;
+            } else {
+                writer.write_all(b"430 no such article\r\n").await?;
+            }
+        } else if let Ok(num) = arg.parse::<u64>() {
+            if let Some(article) = storage.get_article_by_number(current_group, num).await? {
+                *current_article = Some(num);
+                writer.write_all(b"222 0 article body follows\r\n").await?;
+                writer.write_all(article.body.as_bytes()).await?;
+                writer.write_all(b"\r\n.\r\n").await?;
+            } else {
+                writer
+                    .write_all(b"423 no such article number in this group\r\n")
+                    .await?;
+            }
+        } else {
+            writer.write_all(b"501 invalid id\r\n").await?;
+        }
+    } else if let Some(num) = *current_article {
+        if let Some(article) = storage.get_article_by_number(current_group, num).await? {
+            writer.write_all(b"222 0 article body follows\r\n").await?;
+            writer.write_all(article.body.as_bytes()).await?;
+            writer.write_all(b"\r\n.\r\n").await?;
+        } else {
+            writer.write_all(b"420 no current article selected\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"420 no current article selected\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_stat<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    current_group: &str,
+    current_article: &mut Option<u64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(arg) = args.get(0) {
+        if let Ok(num) = arg.parse::<u64>() {
+            if storage.get_article_by_number(current_group, num).await?.is_some() {
+                *current_article = Some(num);
+                writer.write_all(b"223 0 article exists\r\n").await?;
+            } else {
+                writer
+                    .write_all(b"423 no such article number in this group\r\n")
+                    .await?;
+            }
+        } else if arg.starts_with('<') && arg.ends_with('>') {
+            if storage.get_article_by_id(arg).await?.is_some() {
+                writer.write_all(b"223 0 article exists\r\n").await?;
+            } else {
+                writer.write_all(b"430 no such article\r\n").await?;
+            }
+        } else {
+            writer.write_all(b"501 invalid id\r\n").await?;
+        }
+    } else if let Some(num) = *current_article {
+        if storage.get_article_by_number(current_group, num).await?.is_some() {
+            writer.write_all(b"223 0 article exists\r\n").await?;
+        } else {
+            writer.write_all(b"420 no current article selected\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"420 no current article selected\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_list<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(keyword) = args.get(0) {
+        if keyword.eq_ignore_ascii_case("NEWSGROUPS") {
+            let groups = storage.list_groups().await?;
+            writer.write_all(b"215 descriptions follow\r\n").await?;
+            for g in groups {
+                writer
+                    .write_all(format!("{} \r\n", g).as_bytes())
+                    .await?;
+            }
+            writer.write_all(b".\r\n").await?;
+            return Ok(());
+        } else {
+            writer.write_all(b"501 unknown keyword\r\n").await?;
+            return Ok(());
+        }
+    }
+
+    let groups = storage.list_groups().await?;
+    writer.write_all(b"215 list of newsgroups follows\r\n").await?;
+    for g in groups {
+        writer.write_all(format!("{} 0 0 y\r\n", g).as_bytes()).await?;
+    }
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_listgroup<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    current_group: &mut String,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let group = if let Some(name) = args.get(0) {
+        *current_group = name.clone();
+        name.as_str()
+    } else {
+        current_group.as_str()
+    };
+    let nums = storage.list_article_numbers(group).await?;
+    writer.write_all(b"211 article numbers follow\r\n").await?;
+    for n in nums {
+        writer.write_all(format!("{}\r\n", n).as_bytes()).await?;
+    }
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_next<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    current_group: &str,
+    current_article: &mut Option<u64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(curr) = *current_article {
+        let next = curr + 1;
+        if storage
+            .get_article_by_number(current_group, next)
+            .await?
+            .is_some()
+        {
+            *current_article = Some(next);
+            writer.write_all(b"223 0 article exists\r\n").await?;
+        } else {
+            writer.write_all(b"421 no next article\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"420 no current article selected\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_last<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    current_group: &str,
+    current_article: &mut Option<u64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(curr) = *current_article {
+        if curr > 1 {
+            let prev = curr - 1;
+            if storage
+                .get_article_by_number(current_group, prev)
+                .await?
+                .is_some()
+            {
+                *current_article = Some(prev);
+                writer.write_all(b"223 0 article exists\r\n").await?;
+            } else {
+                writer.write_all(b"422 no previous article\r\n").await?;
+            }
+        } else {
+            writer.write_all(b"422 no previous article\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"420 no current article selected\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_newgroups<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if args.len() < 2 {
+        writer.write_all(b"501 not enough arguments\r\n").await?;
+        return Ok(());
+    }
+
+    let date = &args[0];
+    let time = &args[1];
+    if !(date.len() == 6 || date.len() == 8) || !date.chars().all(|c| c.is_ascii_digit()) {
+        writer.write_all(b"501 invalid date\r\n").await?;
+        return Ok(());
+    }
+    if time.len() != 6 || !time.chars().all(|c| c.is_ascii_digit()) {
+        writer.write_all(b"501 invalid time\r\n").await?;
+        return Ok(());
+    }
+    if let Some(arg) = args.get(2) {
+        if !arg.eq_ignore_ascii_case("GMT") {
+            writer.write_all(b"501 invalid argument\r\n").await?;
+            return Ok(());
+        }
+    }
+
+    let fmt = if date.len() == 6 { "%y%m%d" } else { "%Y%m%d" };
+    let naive_date = match chrono::NaiveDate::parse_from_str(date, fmt) {
+        Ok(d) => d,
+        Err(_) => {
+            writer.write_all(b"501 invalid date\r\n").await?;
+            return Ok(());
+        }
+    };
+    let naive_time = match chrono::NaiveTime::parse_from_str(time, "%H%M%S") {
+        Ok(t) => t,
+        Err(_) => {
+            writer.write_all(b"501 invalid time\r\n").await?;
+            return Ok(());
+        }
+    };
+    let since = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+        naive_date.and_time(naive_time),
+        chrono::Utc,
+    );
+
+    let groups = storage.list_groups_since(since).await?;
+    writer
+        .write_all(b"231 list of new newsgroups follows\r\n")
+        .await?;
+    for g in groups {
+        writer.write_all(format!("{}\r\n", g).as_bytes()).await?;
+    }
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_newnews<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    storage: &DynStorage,
+    args: &[String],
+    _current_group: &str,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if args.len() < 3 {
+        writer.write_all(b"501 not enough arguments\r\n").await?;
+        return Ok(());
+    }
+
+    let wildmat = &args[0];
+    let date = &args[1];
+    let time = &args[2];
+    if !(date.len() == 6 || date.len() == 8) || !date.chars().all(|c| c.is_ascii_digit()) {
+        writer.write_all(b"501 invalid date\r\n").await?;
+        return Ok(());
+    }
+    if time.len() != 6 || !time.chars().all(|c| c.is_ascii_digit()) {
+        writer.write_all(b"501 invalid time\r\n").await?;
+        return Ok(());
+    }
+    if let Some(arg) = args.get(3) {
+        if !arg.eq_ignore_ascii_case("GMT") {
+            writer.write_all(b"501 invalid argument\r\n").await?;
+            return Ok(());
+        }
+    }
+
+    let fmt = if date.len() == 6 { "%y%m%d" } else { "%Y%m%d" };
+    let naive_date = match chrono::NaiveDate::parse_from_str(date, fmt) {
+        Ok(d) => d,
+        Err(_) => {
+            writer.write_all(b"501 invalid date\r\n").await?;
+            return Ok(());
+        }
+    };
+    let naive_time = match chrono::NaiveTime::parse_from_str(time, "%H%M%S") {
+        Ok(t) => t,
+        Err(_) => {
+            writer.write_all(b"501 invalid time\r\n").await?;
+            return Ok(());
+        }
+    };
+    let since = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+        naive_date.and_time(naive_time),
+        chrono::Utc,
+    );
+
+    let groups = storage.list_groups().await?;
+    let mut ids = Vec::new();
+    for g in groups {
+        if wildmat::wildmat(wildmat, &g) {
+            ids.extend(storage.list_article_ids_since(&g, since).await?);
+        }
+    }
+
+    writer
+        .write_all(b"230 list of new articles follows\r\n")
+        .await?;
+    for id in ids {
+        writer.write_all(format!("{}\r\n", id).as_bytes()).await?;
+    }
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_capabilities<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    writer.write_all(b"101 Capability list follows\r\n").await?;
+    writer.write_all(b"VERSION 2\r\n").await?;
+    writer.write_all(b"READER\r\n").await?;
+    writer.write_all(b"POST\r\n").await?;
+    writer.write_all(b"NEWNEWS\r\n").await?;
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_date<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    use chrono::Utc;
+    let now = Utc::now().format("%Y%m%d%H%M%S").to_string();
+    writer
+        .write_all(format!("111 {}\r\n", now).as_bytes())
+        .await?;
+    Ok(())
+}
+
+async fn handle_help<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    writer.write_all(b"100 help text follows\r\n").await?;
+    writer
+        .write_all(
+            b"CAPABILITIES\r\nMODE READER\r\nGROUP\r\nLIST\r\nLISTGROUP\r\nARTICLE\r\nHEAD\r\nBODY\r\nSTAT\r\nNEXT\r\nLAST\r\nNEWGROUPS\r\nNEWNEWS\r\nPOST\r\nDATE\r\nHELP\r\nQUIT\r\n",
+        )
+        .await?;
+    writer.write_all(b".\r\n").await?;
+    Ok(())
+}
+
+async fn handle_mode<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    args: &[String],
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if let Some(arg) = args.get(0) {
+        if arg.eq_ignore_ascii_case("READER") {
+            writer.write_all(b"200 Reader mode acknowledged\r\n").await?;
+        } else {
+            writer.write_all(b"501 unknown mode\r\n").await?;
+        }
+    } else {
+        writer.write_all(b"501 missing mode\r\n").await?;
+    }
+    Ok(())
+}
+
+async fn handle_post<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    storage: &DynStorage,
+    current_group: &str,
+) -> Result<(), Box<dyn Error + Send + Sync>>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    writer
+        .write_all(b"340 send article to be posted. End with <CR-LF>.<CR-LF>\r\n")
+        .await?;
+    let mut msg = String::new();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await?;
+        if line.trim_end() == "." {
+            break;
+        }
+        msg.push_str(&line);
+    }
+    let (_, message) = parse_message(&msg).map_err(|_| "invalid message")?;
+    let _ = storage.store_article(current_group, &message).await?;
+    writer.write_all(b"240 article received\r\n").await?;
+    Ok(())
+}
+
+pub async fn handle_client(
+    mut socket: TcpStream,
+    storage: DynStorage,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let (read_half, mut write_half) = socket.split();
+    let mut reader = BufReader::new(read_half);
+    write_half.write_all(b"200 NNTP Service Ready\r\n").await?;
+    let mut line = String::new();
+    let mut current_group = String::from("misc");
+    let mut current_article: Option<u64> = None;
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        let (_, cmd) = match parse_command(trimmed) {
+            Ok(c) => c,
+            Err(_) => {
+                write_half.write_all(b"500 syntax error\r\n").await?;
+                continue;
+            }
+        };
+        match cmd.name.as_str() {
+            "QUIT" => {
+                if handle_quit(&mut write_half).await? {
+                    break;
+                }
+            }
+            "GROUP" => {
+                handle_group(&mut write_half, &cmd.args, &mut current_group).await?;
+            }
+            "ARTICLE" => {
+                handle_article(&mut write_half, &storage, &cmd.args, &current_group).await?;
+            }
+            "HEAD" => {
+                handle_head(&mut write_half, &storage, &cmd.args, &current_group, &mut current_article).await?;
+            }
+            "BODY" => {
+                handle_body(&mut write_half, &storage, &cmd.args, &current_group, &mut current_article).await?;
+            }
+            "STAT" => {
+                handle_stat(&mut write_half, &storage, &cmd.args, &current_group, &mut current_article).await?;
+            }
+            "LIST" => {
+                handle_list(&mut write_half, &storage, &cmd.args).await?;
+            }
+            "LISTGROUP" => {
+                handle_listgroup(&mut write_half, &storage, &cmd.args, &mut current_group).await?;
+            }
+            "NEXT" => {
+                handle_next(&mut write_half, &storage, &current_group, &mut current_article).await?;
+            }
+            "LAST" => {
+                handle_last(&mut write_half, &storage, &current_group, &mut current_article).await?;
+            }
+            "NEWGROUPS" => {
+                handle_newgroups(&mut write_half, &storage, &cmd.args).await?;
+            }
+            "NEWNEWS" => {
+                handle_newnews(&mut write_half, &storage, &cmd.args, &current_group).await?;
+            }
+            "CAPABILITIES" => {
+                handle_capabilities(&mut write_half).await?;
+            }
+            "DATE" => {
+                handle_date(&mut write_half).await?;
+            }
+            "HELP" => {
+                handle_help(&mut write_half).await?;
+            }
+            "MODE" => {
+                handle_mode(&mut write_half, &cmd.args).await?;
+            }
+            "POST" => {
+                handle_post(&mut reader, &mut write_half, &storage, &current_group).await?;
+            }
+            _ => {
+                write_half.write_all(b"500 command not recognized\r\n").await?;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 
-use renews::{parse_command, parse_message, Message};
-use renews::storage::{self, sqlite::SqliteStorage, DynStorage};
+use renews::storage::sqlite::SqliteStorage;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -15,116 +13,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let (socket, _) = listener.accept().await?;
         let storage = storage.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_client(socket, storage).await {
+            if let Err(e) = renews::handle_client(socket, storage).await {
                 eprintln!("client error: {e}");
             }
         });
     }
 }
 
-async fn handle_client(
-    mut socket: TcpStream,
-    storage: DynStorage,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let (read_half, mut write_half) = socket.split();
-    let mut reader = BufReader::new(read_half);
-    write_half.write_all(b"200 NNTP Service Ready\r\n").await?;
-    let mut line = String::new();
-    let mut current_group = String::from("misc");
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).await?;
-        if n == 0 {
-            break;
-        }
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        let (_, cmd) = match parse_command(trimmed) {
-            Ok(c) => c,
-            Err(_) => {
-                write_half.write_all(b"500 syntax error\r\n").await?;
-                continue;
-            }
-        };
-        match cmd.name.as_str() {
-            "QUIT" => {
-                write_half.write_all(b"205 closing connection\r\n").await?;
-                break;
-            }
-            "GROUP" => {
-                if let Some(name) = cmd.args.get(0) {
-                    current_group = name.clone();
-                    write_half
-                        .write_all(format!("211 0 1 1 {}\r\n", name).as_bytes())
-                        .await?;
-                } else {
-                    write_half.write_all(b"411 missing group\r\n").await?;
-                }
-            }
-            "ARTICLE" => {
-                if let Some(arg) = cmd.args.get(0) {
-                    if arg.starts_with('<') && arg.ends_with('>') {
-                        if let Some(article) = storage.get_article_by_id(arg).await? {
-                            write_half
-                                .write_all(b"220 0 article follows\r\n")
-                                .await?;
-                            for (k, v) in article.headers.iter() {
-                                write_half
-                                    .write_all(format!("{}: {}\r\n", k, v).as_bytes())
-                                    .await?;
-                            }
-                            write_half.write_all(b"\r\n").await?;
-                            write_half.write_all(article.body.as_bytes()).await?;
-                            write_half.write_all(b"\r\n.\r\n").await?;
-                        } else {
-                            write_half.write_all(b"430 no such article\r\n").await?;
-                        }
-                    } else if let Ok(num) = arg.parse::<u64>() {
-                        if let Some(article) =
-                            storage.get_article_by_number(&current_group, num).await?
-                        {
-                            write_half
-                                .write_all(b"220 0 article follows\r\n")
-                                .await?;
-                            for (k, v) in article.headers.iter() {
-                                write_half
-                                    .write_all(format!("{}: {}\r\n", k, v).as_bytes())
-                                    .await?;
-                            }
-                            write_half.write_all(b"\r\n").await?;
-                            write_half.write_all(article.body.as_bytes()).await?;
-                            write_half.write_all(b"\r\n.\r\n").await?;
-                        } else {
-                            write_half.write_all(b"423 no such article number in this group\r\n").await?;
-                        }
-                    } else {
-                        write_half.write_all(b"501 invalid id\r\n").await?;
-                    }
-                } else {
-                    write_half.write_all(b"501 missing id\r\n").await?;
-                }
-            }
-            "POST" => {
-                write_half
-                    .write_all(b"340 send article to be posted. End with <CR-LF>.<CR-LF>\r\n")
-                    .await?;
-                let mut msg = String::new();
-                loop {
-                    line.clear();
-                    reader.read_line(&mut line).await?;
-                    if line.trim_end() == "." {
-                        break;
-                    }
-                    msg.push_str(&line);
-                }
-                let (_, message) = parse_message(&msg).map_err(|_| "invalid message")?;
-                let _ = storage.store_article(&current_group, &message).await?;
-                write_half.write_all(b"240 article received\r\n").await?;
-            }
-            _ => {
-                write_half.write_all(b"500 command not recognized\r\n").await?;
-            }
-        }
-    }
-    Ok(())
-}
 

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,0 +1,286 @@
+use renews::{handle_client, parse_message};
+use renews::storage::{sqlite::SqliteStorage, Storage};
+use chrono::{Duration, Utc};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+#[tokio::test]
+async fn head_and_list_commands() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: T\r\n\r\nBody").unwrap();
+    storage.store_article("misc", &msg).await.unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        handle_client(sock, store_clone).await.unwrap();
+    });
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("200"));
+    line.clear();
+
+    write_half.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("200"));
+    line.clear();
+
+    write_half.write_all(b"GROUP misc\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("211"));
+    line.clear();
+
+    write_half.write_all(b"HEAD 1\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("221"));
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        if line.trim_end() == "." {
+            break;
+        }
+    }
+    line.clear();
+
+    write_half.write_all(b"LIST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut found = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." {
+            break;
+        }
+        if trimmed.starts_with("misc") {
+            found = true;
+        }
+    }
+    assert!(found);
+
+    line.clear();
+    write_half.write_all(b"QUIT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("205"));
+}
+
+#[tokio::test]
+async fn listgroup_and_navigation_commands() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
+    let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
+    storage.store_article("misc", &m1).await.unwrap();
+    storage.store_article("misc", &m2).await.unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        handle_client(sock, store_clone).await.unwrap();
+    });
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    write_half.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    write_half.write_all(b"GROUP misc\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    write_half.write_all(b"LISTGROUP\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("211"));
+    let mut nums = Vec::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." {
+            break;
+        }
+        nums.push(trimmed.to_string());
+    }
+    assert_eq!(nums, vec!["1", "2"]);
+
+    line.clear();
+    write_half.write_all(b"HEAD 1\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        if line.trim_end() == "." {
+            break;
+        }
+    }
+    line.clear();
+
+    write_half.write_all(b"NEXT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("223"));
+    line.clear();
+
+    write_half.write_all(b"LAST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("223"));
+    line.clear();
+
+    // requesting all groups since the epoch should return the "misc" group
+    write_half.write_all(b"NEWGROUPS 19700101 000000\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("231"));
+    let mut groups_list = Vec::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        groups_list.push(trimmed.to_string());
+    }
+    assert!(groups_list.contains(&"misc".to_string()));
+    line.clear();
+
+    // with a future time we should see no groups listed
+    let future = Utc::now() + Duration::seconds(1);
+    let date = future.format("%Y%m%d").to_string();
+    let time = future.format("%H%M%S").to_string();
+    write_half
+        .write_all(format!("NEWGROUPS {} {}\r\n", date, time).as_bytes())
+        .await
+        .unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("231"));
+    let mut none = true;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        none = false;
+    }
+    assert!(none);
+
+    // clear buffer before issuing NEWNEWS
+    line.clear();
+
+    write_half.write_all(b"NEWNEWS misc 19700101 000000\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    eprintln!("NEWNEWS response: {}", line.trim_end());
+    assert!(line.starts_with("230"));
+    let mut ids = Vec::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." {
+            break;
+        }
+        ids.push(trimmed.to_string());
+    }
+    assert!(ids.contains(&"<1@test>".to_string()));
+
+    write_half.write_all(b"QUIT\r\n").await.unwrap();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.unwrap() == 0 {
+            break;
+        }
+        if line.starts_with("205") {
+            break;
+        }
+    }
+    assert!(line.starts_with("205"));
+}
+
+#[tokio::test]
+async fn capabilities_and_misc_commands() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        handle_client(sock, store_clone).await.unwrap();
+    });
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    write_half.write_all(b"CAPABILITIES\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("101"));
+    let mut has_version = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed.starts_with("VERSION") { has_version = true; }
+    }
+    assert!(has_version);
+    line.clear();
+
+    write_half.write_all(b"DATE\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("111"));
+    assert_eq!(line.trim_end().len(), 18); // "111 " + 14 digits
+    line.clear();
+
+    write_half.write_all(b"HELP\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("100"));
+    let mut has_cap = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed == "CAPABILITIES" { has_cap = true; }
+    }
+    assert!(has_cap);
+
+    line.clear();
+    write_half.write_all(b"LIST NEWSGROUPS\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut seen = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed.starts_with("misc") { seen = true; }
+    }
+    assert!(seen);
+
+    line.clear();
+    write_half.write_all(b"QUIT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("205"));
+}


### PR DESCRIPTION
## Summary
- extend storage with an `inserted_at` timestamp
- expose a `list_article_ids_since` method
- filter NEWNEWS results using the stored timestamps
- adjust integration tests for NEWNEWS behavior


------
https://chatgpt.com/codex/tasks/task_e_6860346768708326808559a95961ce75