### PR TITLE
Add TOML configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1162,6 +1163,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -1612,6 +1622,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2105,6 +2156,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ async-trait = "0.1"
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+port = 1199
+groups = ["misc.news"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,17 @@
+use serde::Deserialize;
+use std::error::Error;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub port: u16,
+    #[serde(default)]
+    pub groups: Vec<String>,
+}
+
+impl Config {
+    pub fn from_file(path: &str) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let text = std::fs::read_to_string(path)?;
+        let cfg: Config = toml::from_str(&text)?;
+        Ok(cfg)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub fn parse_message(input: &str) -> IResult<&str, Message> {
 
 pub mod storage;
 pub mod wildmat;
+pub mod config;
 
 use crate::storage::DynStorage;
 use std::error::Error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,18 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 
 use renews::storage::sqlite::SqliteStorage;
+use renews::storage::Storage;
+use renews::config::Config;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let cfg = Config::from_file("config.toml")?;
     let storage = Arc::new(SqliteStorage::new("sqlite:news.db").await?);
-    let listener = TcpListener::bind("127.0.0.1:1199").await?;
+    for g in &cfg.groups {
+        storage.add_group(g).await?;
+    }
+    let addr = format!("127.0.0.1:{}", cfg.port);
+    let listener = TcpListener::bind(&addr).await?;
     loop {
         let (socket, _) = listener.accept().await?;
         let storage = storage.clone();


### PR DESCRIPTION
## Summary
- switch config format from JSON to TOML
- update Config module to parse TOML
- load `config.toml` in the main server
- add `toml` crate

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686277386b248326b2a3c0c5aeadd04e