### PR TITLE
Add TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,10 +1016,12 @@ dependencies = [
  "async-trait",
  "chrono",
  "nom",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-rustls",
  "toml",
 ]
 
@@ -1082,6 +1084,7 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
+ "log",
  "ring",
  "rustls-webpki",
  "sct",
@@ -1610,6 +1613,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
+tokio-rustls = "0.24"
+rustls-pemfile = "1"

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,5 @@
 port = 1199
 groups = ["misc.news"]
+tls_port = 563
+tls_cert = "cert.pem"
+tls_key = "key.pem"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,12 @@ pub struct Config {
     pub port: u16,
     #[serde(default)]
     pub groups: Vec<String>,
+    #[serde(default)]
+    pub tls_port: Option<u16>,
+    #[serde(default)]
+    pub tls_cert: Option<String>,
+    #[serde(default)]
+    pub tls_key: Option<String>,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,30 @@ use std::error::Error;
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
+use tokio_rustls::{rustls, TlsAcceptor};
+use rustls_pemfile::{certs, pkcs8_private_keys};
+use std::fs::File;
+use std::io::BufReader;
 
 use renews::storage::sqlite::SqliteStorage;
 use renews::storage::Storage;
 use renews::config::Config;
+
+fn load_tls_config(cert_path: &str, key_path: &str) -> Result<rustls::ServerConfig, Box<dyn Error + Send + Sync>> {
+    let cert_file = &mut BufReader::new(File::open(cert_path)?);
+    let key_file = &mut BufReader::new(File::open(key_path)?);
+    let certs = certs(cert_file)?.into_iter().map(rustls::Certificate).collect();
+    let mut keys = pkcs8_private_keys(key_file)?;
+    if keys.is_empty() {
+        return Err("no private key found".into());
+    }
+    let key = rustls::PrivateKey(keys.remove(0));
+    let config = rustls::ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+    Ok(config)
+}
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -16,15 +36,47 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
     let addr = format!("127.0.0.1:{}", cfg.port);
     let listener = TcpListener::bind(&addr).await?;
-    loop {
-        let (socket, _) = listener.accept().await?;
-        let storage = storage.clone();
+    let storage_clone = storage.clone();
+    tokio::spawn(async move {
+        loop {
+            let (socket, _) = listener.accept().await.unwrap();
+            let st = storage_clone.clone();
+            tokio::spawn(async move {
+                if let Err(e) = renews::handle_client(socket, st).await {
+                    eprintln!("client error: {e}");
+                }
+            });
+        }
+    });
+
+    if let (Some(tls_port), Some(cert), Some(key)) =
+        (cfg.tls_port, cfg.tls_cert.as_ref(), cfg.tls_key.as_ref())
+    {
+        let tls_addr = format!("127.0.0.1:{}", tls_port);
+        let tls_listener = TcpListener::bind(&tls_addr).await?;
+        let tls_config = TlsAcceptor::from(Arc::new(load_tls_config(cert, key)?));
+        let storage_clone = storage.clone();
         tokio::spawn(async move {
-            if let Err(e) = renews::handle_client(socket, storage).await {
-                eprintln!("client error: {e}");
+            loop {
+                let (socket, _) = tls_listener.accept().await.unwrap();
+                let acceptor = tls_config.clone();
+                let st = storage_clone.clone();
+                tokio::spawn(async move {
+                    match acceptor.accept(socket).await {
+                        Ok(stream) => {
+                            if let Err(e) = renews::handle_client(stream, st).await {
+                                eprintln!("client error: {e}");
+                            }
+                        }
+                        Err(e) => eprintln!("tls error: {e}"),
+                    }
+                });
             }
         });
     }
+
+    tokio::signal::ctrl_c().await?;
+    Ok(())
 }
 
 


### PR DESCRIPTION
## Summary
- support optional TLS listener in config
- implement TLS acceptor logic in main
- make `handle_client` generic to handle TLS streams
- document TLS fields in `config.toml`
- wait for Ctrl-C instead of sleeping forever

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68628f20ffac8326ae64c8506178fa55