### PR TITLE
Add configuration docs and systemd unit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Renews
+
+Renews is a minimal NNTP server implemented in Rust.  It stores articles in an
+SQLite database and supports a configurable set of newsgroups.  The server can
+optionally accept NNTP over TLS when the TLS parameters are provided.
+
+## Building
+
+```bash
+cargo build --release
+```
+This produces the `renews` binary in `target/release/`.
+
+## Configuration
+
+Configuration is loaded from `config.toml` in the working directory.  The
+following keys are recognised:
+
+- `port` - TCP port for plain NNTP connections.
+- `groups` - list of newsgroups that will be created on start-up.
+- `tls_port` - optional port for NNTP over TLS.
+- `tls_cert` - path to the TLS certificate in PEM format.
+- `tls_key` - path to the TLS private key in PEM format.
+
+An example configuration is provided in the repository:
+
+```toml
+port = 1199
+groups = ["misc.news"]
+tls_port = 563
+tls_cert = "cert.pem"
+tls_key = "key.pem"
+```
+
+`tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be
+enabled.
+
+## Deployment with systemd
+
+The service expects `config.toml` in its working directory.  A simple systemd
+unit may look like this:
+
+```ini
+[Unit]
+Description=Renews NNTP server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/renews
+WorkingDirectory=/opt/renews
+Restart=on-failure
+User=renews
+Group=renews
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Install the file as `/etc/systemd/system/renews.service` and run
+`systemctl enable --now renews` to start the server at boot.
+

--- a/examples/systemd/renews.service
+++ b/examples/systemd/renews.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Renews NNTP server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/renews
+WorkingDirectory=/opt/renews
+Restart=on-failure
+User=renews
+Group=renews
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
## Summary
- document available configuration options
- provide instructions for running under systemd
- include an example `renews.service` unit file

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6862ba5380a48326b3bcdd4bcee850ec