### PR TITLE
Fix LIST command watermarks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,8 +424,11 @@ async fn handle_list<W: AsyncWrite + Unpin>(
         .write_all(b"215 list of newsgroups follows\r\n")
         .await?;
     for g in groups {
+        let nums = storage.list_article_numbers(&g).await?;
+        let high = nums.last().copied().unwrap_or(0);
+        let low = nums.first().copied().unwrap_or(0);
         writer
-            .write_all(format!("{} 0 0 y\r\n", g).as_bytes())
+            .write_all(format!("{} {} {} y\r\n", g, high, low).as_bytes())
             .await?;
     }
     writer.write_all(b".\r\n").await?;

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -555,7 +555,8 @@ async fn list_newsgroups_returns_groups() {
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
         if trimmed == "." { break; }
-        groups.push(trimmed.to_string());
+        let name = trimmed.split_whitespace().next().unwrap_or("");
+        groups.push(name.to_string());
     }
     assert!(groups.contains(&"misc.test".to_string()));
     assert!(groups.contains(&"alt.test".to_string()));


### PR DESCRIPTION
## Summary
- compute high and low article numbers for LIST command
- adjust LIST NEWSGROUPS integration test to parse group names

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6862d17c617483268724d255fa6dee0e