### PR TITLE
Fix RFC3977 compliance issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub fn parse_command(input: &str) -> IResult<&str, Command> {
     Ok((
         input,
         Command {
-            name: name.to_string(),
+            name: name.to_ascii_uppercase(),
             args: args_vec,
         },
     ))
@@ -729,7 +729,7 @@ where
     loop {
         line.clear();
         reader.read_line(&mut line).await?;
-        if line.trim_end() == "." {
+        if line == ".\r\n" || line == ".\n" {
             break;
         }
         if line.starts_with("..") {

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -150,6 +150,22 @@ async fn mode_reader_success() {
     assert!(line.starts_with("200"));
 }
 
+#[tokio::test]
+async fn commands_are_case_insensitive() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = setup_server(storage).await;
+    let (mut reader, mut writer) = connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"mode reader\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("200"));
+    line.clear();
+    writer.write_all(b"quit\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("205"));
+}
 
 #[tokio::test]
 async fn group_select_returns_211() {
@@ -517,7 +533,9 @@ async fn listgroup_returns_numbers() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
+        if trimmed == "." {
+            break;
+        }
         nums.push(trimmed.to_string());
     }
     assert_eq!(nums, vec!["1"]);
@@ -554,7 +572,9 @@ async fn list_newsgroups_returns_groups() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
+        if trimmed == "." {
+            break;
+        }
         let name = trimmed.split_whitespace().next().unwrap_or("");
         groups.push(name.to_string());
     }
@@ -584,7 +604,9 @@ async fn newnews_lists_recent_articles() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
+        if trimmed == "." {
+            break;
+        }
         ids.push(trimmed.to_string());
     }
     assert_eq!(ids, vec!["<1@test>".to_string()]);
@@ -616,9 +638,10 @@ async fn newnews_no_matches_returns_empty() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
+        if trimmed == "." {
+            break;
+        }
         none = false;
     }
     assert!(none);
 }
-


### PR DESCRIPTION
## Summary
- ensure command parsing is case-insensitive
- fix POST termination check to require exact terminator line
- add regression test for lowercase commands

## Testing
- `cargo test --all --tests`

------
https://chatgpt.com/codex/tasks/task_e_6862d75f35608326a829fdb5b604c76b