### PR TITLE
Add database path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ following keys are recognised:
 
 - `port` - TCP port for plain NNTP connections.
 - `groups` - list of newsgroups that will be created on start-up.
+- `db_path` - path to the SQLite database file. Defaults to `/var/spool/renews.db`.
 - `tls_port` - optional port for NNTP over TLS.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
@@ -27,6 +28,7 @@ An example configuration is provided in the repository:
 ```toml
 port = 1199
 groups = ["misc.news"]
+db_path = "/var/spool/renews.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 port = 1199
 groups = ["misc.news"]
+db_path = "/var/spool/renews.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,17 @@
 use serde::Deserialize;
 use std::error::Error;
 
+fn default_db_path() -> String {
+    "/var/spool/renews.db".into()
+}
+
 #[derive(Deserialize)]
 pub struct Config {
     pub port: u16,
     #[serde(default)]
     pub groups: Vec<String>,
+    #[serde(default = "default_db_path")]
+    pub db_path: String,
     #[serde(default)]
     pub tls_port: Option<u16>,
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ fn load_tls_config(cert_path: &str, key_path: &str) -> Result<rustls::ServerConf
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cfg = Config::from_file("config.toml")?;
-    let storage = Arc::new(SqliteStorage::new("sqlite:news.db").await?);
+    let db_conn = format!("sqlite:{}", cfg.db_path);
+    let storage = Arc::new(SqliteStorage::new(&db_conn).await?);
     for g in &cfg.groups {
         storage.add_group(g).await?;
     }


### PR DESCRIPTION
## Summary
- allow configuration of SQLite database path
- default database path is `/var/spool/renews.db`
- update example `config.toml`
- document new option in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863dd4952988326bb2b716b2e524483