### PR TITLE
Restrict POST to TLS connections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             let (socket, _) = listener.accept().await.unwrap();
             let st = storage_clone.clone();
             tokio::spawn(async move {
-                if let Err(e) = renews::handle_client(socket, st).await {
+                if let Err(e) = renews::handle_client(socket, st, false).await {
                     eprintln!("client error: {e}");
                 }
             });
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 tokio::spawn(async move {
                     match acceptor.accept(socket).await {
                         Ok(stream) => {
-                            if let Err(e) = renews::handle_client(stream, st).await {
+                            if let Err(e) = renews::handle_client(stream, st, true).await {
                                 eprintln!("client error: {e}");
                             }
                         }

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -13,7 +13,7 @@ async fn setup_server(
     let store_clone = storage.clone();
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone).await.unwrap();
+        handle_client(sock, store_clone, false).await.unwrap();
     });
     (addr, handle)
 }
@@ -147,7 +147,7 @@ async fn mode_reader_success() {
     line.clear();
     writer.write_all(b"MODE READER\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
-    assert!(line.starts_with("200"));
+    assert!(line.starts_with("201"));
 }
 
 #[tokio::test]
@@ -160,7 +160,7 @@ async fn commands_are_case_insensitive() {
     line.clear();
     writer.write_all(b"mode reader\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
-    assert!(line.starts_with("200"));
+    assert!(line.starts_with("201"));
     line.clear();
     writer.write_all(b"quit\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();


### PR DESCRIPTION
## Summary
- add TLS awareness to `handle_mode`
- send a 201 code on non-secure connections
- return correct status for `MODE READER` and capabilities
- update tests for the new greeting and `MODE` behavior

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686405c109e48326bfea661cb10c60c5