### PR TITLE
Add per-group article retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ following keys are recognised:
 - `tls_port` - optional port for NNTP over TLS.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
+- `default_retention_days` - default number of days to keep articles.
+- `retention` - list of retention rules which can match a `group` exactly or a
+  `pattern` using wildmat syntax to override the default.
 
 An example configuration is provided in the repository:
 
@@ -33,6 +36,15 @@ db_path = "/var/spool/renews.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
+default_retention_days = 30
+
+[[retention]]
+pattern = "short.*"
+days = 7
+
+[[retention]]
+group = "misc.news"
+days = 60
 ```
 
 `tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/config.toml
+++ b/config.toml
@@ -4,3 +4,12 @@ db_path = "/var/spool/renews.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
+default_retention_days = 30
+
+[[retention]]
+pattern = "short.*"
+days = 7
+
+[[retention]]
+group = "misc.news"
+days = 60

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub fn parse_message(input: &str) -> IResult<&str, Message> {
 }
 
 pub mod config;
+pub mod retention;
 pub mod storage;
 pub mod wildmat;
 

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,0 +1,19 @@
+use crate::config::Config;
+use crate::storage::Storage;
+use chrono::Utc;
+use std::error::Error;
+
+pub async fn cleanup_expired_articles(
+    storage: &dyn Storage,
+    cfg: &Config,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let groups = storage.list_groups().await?;
+    for g in groups {
+        if let Some(ret) = cfg.retention_for_group(&g) {
+            let cutoff = Utc::now() - ret;
+            storage.purge_group_before(&g, cutoff).await?;
+        }
+    }
+    storage.purge_orphan_messages().await?;
+    Ok(())
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,18 @@
+use renews::config::Config;
+
+#[test]
+fn retention_rules_match() {
+    let toml = r#"port = 1199
+default_retention_days = 10
+[[retention]]
+pattern = "foo.*"
+days = 1
+[[retention]]
+group = "foo.bar"
+days = 5
+"#;
+    let cfg: Config = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.retention_for_group("misc").unwrap().num_days(), 10);
+    assert_eq!(cfg.retention_for_group("foo.test").unwrap().num_days(), 1);
+    assert_eq!(cfg.retention_for_group("foo.bar").unwrap().num_days(), 5);
+}

--- a/tests/retention.rs
+++ b/tests/retention.rs
@@ -1,0 +1,27 @@
+use renews::retention::cleanup_expired_articles;
+use renews::{
+    config::Config,
+    parse_message,
+    storage::{Storage, sqlite::SqliteStorage},
+};
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn cleanup_removes_expired() {
+    let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=0").unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
+    storage.store_article("misc", &msg).await.unwrap();
+    sleep(StdDuration::from_secs(1)).await;
+    cleanup_expired_articles(&*storage, &cfg).await.unwrap();
+    assert!(
+        storage
+            .get_article_by_id("<1@test>")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}


### PR DESCRIPTION
## Summary
- support per-group retention configuration via `default_retention_days` and `[[retention]]` entries
- implement SQLite storage purging and orphan cleanup
- spawn a periodic task to run retention cleanup
- document new config options
- test config matching, storage purge logic and cleanup helper

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686532e8c5e08326b23b4bc74a378989