### PR TITLE
Add support for LIST keywords

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,24 +434,84 @@ async fn handle_list<W: AsyncWrite + Unpin>(
     args: &[String],
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     if let Some(keyword) = args.get(0) {
-        if keyword.eq_ignore_ascii_case("NEWSGROUPS") {
-            let groups = storage.list_groups().await?;
-            writer.write_all(b"215 descriptions follow\r\n").await?;
-            for g in groups {
-                writer.write_all(format!("{} \r\n", g).as_bytes()).await?;
+        match keyword.to_ascii_uppercase().as_str() {
+            "ACTIVE" => {
+                let pattern = args.get(1).map(|s| s.as_str());
+                let groups = storage.list_groups().await?;
+                writer.write_all(b"215 list of newsgroups follows\r\n").await?;
+                for g in groups {
+                    if pattern.map(|p| wildmat::wildmat(p, &g)).unwrap_or(true) {
+                        let nums = storage.list_article_numbers(&g).await?;
+                        let high = nums.last().copied().unwrap_or(0);
+                        let low = nums.first().copied().unwrap_or(0);
+                        writer
+                            .write_all(format!("{} {} {} y\r\n", g, high, low).as_bytes())
+                            .await?;
+                    }
+                }
+                writer.write_all(b".\r\n").await?;
+                return Ok(());
             }
-            writer.write_all(b".\r\n").await?;
-            return Ok(());
-        } else {
-            writer.write_all(b"501 unknown keyword\r\n").await?;
-            return Ok(());
+            "ACTIVE.TIMES" => {
+                let pattern = args.get(1).map(|s| s.as_str());
+                let groups = storage.list_groups_with_times().await?;
+                writer.write_all(b"215 information follows\r\n").await?;
+                for (g, ts) in groups {
+                    if pattern.map(|p| wildmat::wildmat(p, &g)).unwrap_or(true) {
+                        writer
+                            .write_all(format!("{} {} -\r\n", g, ts).as_bytes())
+                            .await?;
+                    }
+                }
+                writer.write_all(b".\r\n").await?;
+                return Ok(());
+            }
+            "DISTRIB.PATS" => {
+                writer.write_all(b"503 Data item not stored\r\n").await?;
+                return Ok(());
+            }
+            "NEWSGROUPS" => {
+                let pattern = args.get(1).map(|s| s.as_str());
+                let groups = storage.list_groups().await?;
+                writer.write_all(b"215 descriptions follow\r\n").await?;
+                for g in groups {
+                    if pattern.map(|p| wildmat::wildmat(p, &g)).unwrap_or(true) {
+                        writer.write_all(format!("{} \r\n", g).as_bytes()).await?;
+                    }
+                }
+                writer.write_all(b".\r\n").await?;
+                return Ok(());
+            }
+            "OVERVIEW.FMT" => {
+                writer.write_all(b"215 Order of fields in overview database.\r\n").await?;
+                writer.write_all(b"Subject:\r\n").await?;
+                writer.write_all(b"From:\r\n").await?;
+                writer.write_all(b"Date:\r\n").await?;
+                writer.write_all(b"Message-ID:\r\n").await?;
+                writer.write_all(b"References:\r\n").await?;
+                writer.write_all(b":bytes\r\n").await?;
+                writer.write_all(b":lines\r\n").await?;
+                writer.write_all(b".\r\n").await?;
+                return Ok(());
+            }
+            "HEADERS" => {
+                writer.write_all(b"215 metadata items supported:\r\n").await?;
+                writer.write_all(b":\r\n").await?;
+                writer.write_all(b":lines\r\n").await?;
+                writer.write_all(b":bytes\r\n").await?;
+                writer.write_all(b".\r\n").await?;
+                return Ok(());
+            }
+            _ => {
+                writer.write_all(b"501 unknown keyword\r\n").await?;
+                return Ok(());
+            }
         }
     }
 
+    // default LIST without keyword behaves like LIST ACTIVE
     let groups = storage.list_groups().await?;
-    writer
-        .write_all(b"215 list of newsgroups follows\r\n")
-        .await?;
+    writer.write_all(b"215 list of newsgroups follows\r\n").await?;
     for g in groups {
         let nums = storage.list_article_numbers(&g).await?;
         let high = nums.last().copied().unwrap_or(0);
@@ -915,6 +975,7 @@ async fn handle_capabilities<W: AsyncWrite + Unpin>(
     writer.write_all(b"STREAMING\r\n").await?;
     writer.write_all(b"OVER MSGID\r\n").await?;
     writer.write_all(b"HDR\r\n").await?;
+    writer.write_all(b"LIST ACTIVE NEWSGROUPS ACTIVE.TIMES DISTRIB.PATS OVERVIEW.FMT HEADERS\r\n").await?;
     writer.write_all(b".\r\n").await?;
     Ok(())
 }

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -53,13 +53,23 @@ async fn capabilities_and_unknown_command() {
     writer.write_all(b"CAPABILITIES\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
     assert!(line.starts_with("101"));
+    let mut has_list = false;
     loop {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
-        if line.trim_end() == "." {
+        let trimmed = line.trim_end();
+        if trimmed == "." {
             break;
         }
+        if trimmed.starts_with("LIST ") {
+            has_list = true;
+            assert!(trimmed.contains("ACTIVE"));
+            assert!(trimmed.contains("NEWSGROUPS"));
+            assert!(trimmed.contains("OVERVIEW.FMT"));
+            assert!(trimmed.contains("HEADERS"));
+        }
     }
+    assert!(has_list);
     line.clear();
     writer.write_all(b"OVER\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
@@ -118,7 +128,7 @@ async fn list_unknown_keyword() {
     line.clear();
     writer.write_all(b"LIST ACTIVE u[ks].*\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
-    assert!(line.starts_with("501"));
+    assert!(line.starts_with("215"));
 }
 
 #[tokio::test]
@@ -580,6 +590,77 @@ async fn list_newsgroups_returns_groups() {
     }
     assert!(groups.contains(&"misc.test".to_string()));
     assert!(groups.contains(&"alt.test".to_string()));
+}
+
+#[tokio::test]
+async fn list_all_keywords() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc.test").await.unwrap();
+    let (addr, _h) = setup_server(storage).await;
+    let (mut reader, mut writer) = connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    writer.write_all(b"LIST ACTIVE\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut found = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed.starts_with("misc.test") { found = true; }
+    }
+    assert!(found);
+    line.clear();
+
+    writer.write_all(b"LIST ACTIVE.TIMES\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut found = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed.starts_with("misc.test") { found = true; }
+    }
+    assert!(found);
+    line.clear();
+
+    writer.write_all(b"LIST DISTRIB.PATS\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("503"));
+    line.clear();
+
+    writer.write_all(b"LIST OVERVIEW.FMT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut has_subject = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed == "Subject:" { has_subject = true; }
+    }
+    assert!(has_subject);
+    line.clear();
+
+    writer.write_all(b"LIST HEADERS\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("215"));
+    let mut has_colon = false;
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.unwrap();
+        let trimmed = line.trim_end();
+        if trimmed == "." { break; }
+        if trimmed == ":" { has_colon = true; }
+    }
+    assert!(has_colon);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- support LIST ACTIVE, ACTIVE.TIMES, DISTRIB.PATS, OVERVIEW.FMT and HEADERS
- advertise LIST keywords via CAPABILITIES
- provide storage method for group creation times
- update tests for new LIST behaviour and add coverage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68656ba2f7348326864825b11d653fd1