### PR TITLE
Refactor tests and add datetime helper

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,29 @@
+use renews::handle_client;
+use renews::storage::{Storage};
+use std::sync::Arc;
+use tokio::io::BufReader;
+use tokio::net::{TcpListener, TcpStream};
+
+pub async fn setup_server(
+    storage: Arc<dyn Storage>,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    let handle = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        handle_client(sock, store_clone, false).await.unwrap();
+    });
+    (addr, handle)
+}
+
+pub async fn connect(
+    addr: std::net::SocketAddr,
+) -> (
+    BufReader<tokio::net::tcp::OwnedReadHalf>,
+    tokio::net::tcp::OwnedWriteHalf,
+) {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (r, w) = stream.into_split();
+    (BufReader::new(r), w)
+}


### PR DESCRIPTION
## Summary
- share test helpers via new `tests/common` module
- use the helpers in integration tests to reduce boilerplate
- refactor date parsing with `parse_datetime` used by NEWGROUPS/NEWNEWS

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68656bd9e25883269abb0d97695ef1f5