### PR TITLE
Fix tests

### DIFF
--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -572,8 +572,8 @@ async fn list_newsgroups_returns_groups() {
 async fn list_all_keywords() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = setup_server(storage).await;
-    let (mut reader, mut writer) = connect(addr).await;
+    let (addr, _h) = common::setup_server(storage).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
     line.clear();


### PR DESCRIPTION
## Summary
- fix compile errors by calling helper functions from the `common` module in the RFC E2E tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686579cf2ac88326998c71d5651102c7