### PR TITLE
Add RFC references

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,3 +1,4 @@
+use chrono::TimeZone;
 use nom::IResult;
 use nom::{
     bytes::complete::{is_not, take_till, take_while1},
@@ -13,6 +14,8 @@ pub struct Command {
     pub args: Vec<String>,
 }
 
+/// Parse a single NNTP command line as described in RFC 3977
+/// Section 3.1 "Commands and Responses".
 pub fn parse_command(input: &str) -> IResult<&str, Command> {
     let (input, name) = take_while1(|c: char| c.is_ascii_alphabetic())(input)?;
     let (input, args) = opt(preceded(space1, separated_list1(space1, is_not(" \r\n"))))(input)?;
@@ -37,6 +40,8 @@ pub struct Response {
     pub text: String,
 }
 
+/// Parse an NNTP response line as specified in RFC 3977
+/// Section 9.4.2 "Initial Response Line Contents".
 pub fn parse_response(input: &str) -> IResult<&str, Response> {
     let parse_code = map_res(digit1, |d: &str| d.parse::<u16>());
     let (input, (code, text)) = tuple((
@@ -59,6 +64,8 @@ pub struct Message {
     pub body: String,
 }
 
+/// Parse a single article header line including folded continuation
+/// lines as defined in RFC 3977 Section 3.6 "Articles".
 fn parse_header_line(mut input: &str) -> IResult<&str, (String, String)> {
     let (i, name) = take_while1(|c: char| c != ':' && c != '\r' && c != '\n')(input)?;
     let (i, _) = char(':')(i)?;
@@ -80,6 +87,9 @@ fn parse_header_line(mut input: &str) -> IResult<&str, (String, String)> {
     Ok((input, (name.to_string(), val)))
 }
 
+/// Parse the header block of an article until the blank line
+/// separating headers from the body, as specified in RFC 3977
+/// Section 3.6.
 fn parse_headers(mut input: &str) -> IResult<&str, Vec<(String, String)>> {
     let mut headers = Vec::new();
     loop {
@@ -94,10 +104,67 @@ fn parse_headers(mut input: &str) -> IResult<&str, Vec<(String, String)>> {
     Ok((input, headers))
 }
 
+/// Parse an entire article consisting of headers and body
+/// following the rules in RFC 3977 Section 3.6.
 pub fn parse_message(input: &str) -> IResult<&str, Message> {
     let (input, headers) = parse_headers(input)?;
     let body = input.to_string();
     Ok(("", Message { headers, body }))
+}
+
+/// Parse the date and time arguments used by NEWGROUPS and NEWNEWS
+/// commands as described in RFC 3977 Sections 7.3.1 and 7.4.1.
+pub fn parse_datetime(
+    date: &str,
+    time: &str,
+    gmt: bool,
+) -> Result<chrono::DateTime<chrono::Utc>, &'static str> {
+    if !(date.len() == 6 || date.len() == 8) || !date.chars().all(|c| c.is_ascii_digit()) {
+        return Err("invalid date");
+    }
+    if time.len() != 6 || !time.chars().all(|c| c.is_ascii_digit()) {
+        return Err("invalid time");
+    }
+    let fmt = if date.len() == 6 { "%y%m%d" } else { "%Y%m%d" };
+    let naive_date = chrono::NaiveDate::parse_from_str(date, fmt).map_err(|_| "invalid date")?;
+    let naive_time =
+        chrono::NaiveTime::parse_from_str(time, "%H%M%S").map_err(|_| "invalid time")?;
+    let naive = naive_date.and_time(naive_time);
+    Ok(if gmt {
+        chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive, chrono::Utc)
+    } else {
+        chrono::Local
+            .from_local_datetime(&naive)
+            .single()
+            .ok_or("invalid local time")?
+            .with_timezone(&chrono::Utc)
+    })
+}
+
+use crate::storage::DynStorage;
+
+/// Parse the article number range format used by several commands
+/// such as LISTGROUP as defined in RFC 3977 Section 6.1.2.
+pub async fn parse_range(
+    storage: &DynStorage,
+    group: &str,
+    spec: &str,
+) -> Result<Vec<u64>, Box<dyn std::error::Error + Send + Sync>> {
+    if let Some((start_s, end_s)) = spec.split_once('-') {
+        let start: u64 = start_s.parse().map_err(|_| "invalid range")?;
+        if end_s.is_empty() {
+            let nums = storage.list_article_numbers(group).await?;
+            Ok(nums.into_iter().filter(|n| *n >= start).collect())
+        } else {
+            let end: u64 = end_s.parse().map_err(|_| "invalid range")?;
+            if end < start {
+                return Ok(Vec::new());
+            }
+            Ok((start..=end).collect())
+        }
+    } else {
+        Ok(vec![spec.parse()?])
+    }
 }
 
 #[cfg(test)]
@@ -166,9 +233,11 @@ mod tests {
         );
         let (_, msg) = parse_message(input).unwrap();
         assert_eq!(msg.headers.len(), 2);
-        assert_eq!(msg.headers[0], ("Subject".into(), "A first continued".into()));
+        assert_eq!(
+            msg.headers[0],
+            ("Subject".into(), "A first continued".into())
+        );
         assert_eq!(msg.headers[1], ("From".into(), "user@example.com".into()));
         assert_eq!(msg.body, "Body");
     }
 }
-


### PR DESCRIPTION
## Summary
- document which RFC 3977 sections each parser and handler implements
- move parse_datetime and parse_range helper functions into `parse.rs`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68659184e9848326ad6ca85a664041ae