### PR TITLE
Add per-group settings with max article size

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ following keys are recognised:
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
 - `default_retention_days` - default number of days to keep articles.
-- `retention` - list of retention rules which can match a `group` exactly or a
-  `pattern` using wildmat syntax to override the default.
+- `default_max_article_bytes` - default maximum article size in bytes. A `K`,
+  `M` or `G` suffix may be used to specify kilobytes, megabytes or gigabytes.
+- `group_settings` - list of per-group rules which can match a `group` exactly or a
+  `pattern` using wildmat syntax to override retention and size defaults.
 
 An example configuration is provided in the repository:
 
@@ -37,14 +39,16 @@ tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
 default_retention_days = 30
+default_max_article_bytes = "1M"
 
-[[retention]]
+[[group_settings]]
 pattern = "short.*"
-days = 7
+retention_days = 7
 
-[[retention]]
+[[group_settings]]
 group = "misc.news"
-days = 60
+retention_days = 60
+max_article_bytes = "2M"
 ```
 
 `tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/config.toml
+++ b/config.toml
@@ -5,11 +5,14 @@ tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
 default_retention_days = 30
+default_max_article_bytes = "1M"
 
-[[retention]]
+
+[[group_settings]]
 pattern = "short.*"
-days = 7
+retention_days = 7
 
-[[retention]]
+[[group_settings]]
 group = "misc.news"
-days = 60
+retention_days = 60
+max_article_bytes = "2M"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,80 @@
 use crate::wildmat::wildmat;
 use chrono::Duration;
 use serde::Deserialize;
+use serde::de::{self, Deserializer, Visitor};
 use std::error::Error;
+use std::fmt;
 
 fn default_db_path() -> String {
     "/var/spool/renews.db".into()
+}
+
+fn parse_size(input: &str) -> Option<u64> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (digits, factor) = match trimmed.chars().last()? {
+        'K' | 'k' => (&trimmed[..trimmed.len() - 1], 1024u64),
+        'M' | 'm' => (&trimmed[..trimmed.len() - 1], 1024u64 * 1024),
+        'G' | 'g' => (&trimmed[..trimmed.len() - 1], 1024u64 * 1024 * 1024),
+        '0'..='9' => (trimmed, 1u64),
+        _ => return None,
+    };
+    digits
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .and_then(|n| n.checked_mul(factor))
+}
+
+fn deserialize_size<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct SizeVisitor;
+
+    impl<'de> Visitor<'de> for SizeVisitor {
+        type Value = Option<u64>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an integer or string with optional K, M, G suffix")
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
+            Ok(Some(v))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if v < 0 {
+                Err(de::Error::custom("size must be positive"))
+            } else {
+                Ok(Some(v as u64))
+            }
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            parse_size(v)
+                .map(Some)
+                .ok_or_else(|| de::Error::custom(format!("invalid size: {}", v)))
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(SizeVisitor)
 }
 
 #[derive(Deserialize, Clone)]
@@ -22,17 +92,22 @@ pub struct Config {
     pub tls_key: Option<String>,
     #[serde(default)]
     pub default_retention_days: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    pub default_max_article_bytes: Option<u64>,
     #[serde(default)]
-    pub retention: Vec<RetentionRule>,
+    pub group_settings: Vec<GroupRule>,
 }
 
 #[derive(Deserialize, Clone)]
-pub struct RetentionRule {
+pub struct GroupRule {
     #[serde(default)]
     pub group: Option<String>,
     #[serde(default)]
     pub pattern: Option<String>,
-    pub days: i64,
+    #[serde(default)]
+    pub retention_days: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    pub max_article_bytes: Option<u64>,
 }
 
 impl Config {
@@ -42,16 +117,15 @@ impl Config {
         Ok(cfg)
     }
 
-    pub fn retention_for_group(&self, group: &str) -> Option<Duration> {
+    fn rule_for_group(&self, group: &str) -> Option<&GroupRule> {
         if let Some(rule) = self
-            .retention
+            .group_settings
             .iter()
             .find(|r| r.group.as_deref() == Some(group))
         {
-            return Some(Duration::days(rule.days));
+            return Some(rule);
         }
-        if let Some(rule) = self
-            .retention
+        self.group_settings
             .iter()
             .filter(|r| r.group.is_none())
             .find(|r| {
@@ -60,9 +134,20 @@ impl Config {
                     .map(|p| wildmat(p, group))
                     .unwrap_or(false)
             })
-        {
-            return Some(Duration::days(rule.days));
+    }
+
+    pub fn retention_for_group(&self, group: &str) -> Option<Duration> {
+        if let Some(rule) = self.rule_for_group(group) {
+            if let Some(days) = rule.retention_days {
+                return Some(Duration::days(days));
+            }
         }
         self.default_retention_days.map(Duration::days)
+    }
+
+    pub fn max_size_for_group(&self, group: &str) -> Option<u64> {
+        self.rule_for_group(group)
+            .and_then(|r| r.max_article_bytes)
+            .or(self.default_max_article_bytes)
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use renews::handle_client;
-use renews::storage::{Storage};
+use renews::storage::Storage;
+use renews::config::Config;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::{TcpListener, TcpStream};
@@ -10,9 +11,24 @@ pub async fn setup_server(
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
+    let cfg: Config = toml::from_str("port=1199").unwrap();
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone, false).await.unwrap();
+        handle_client(sock, store_clone, cfg, false).await.unwrap();
+    });
+    (addr, handle)
+}
+
+pub async fn setup_server_with_cfg(
+    storage: Arc<dyn Storage>,
+    cfg: Config,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    let handle = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        handle_client(sock, store_clone, cfg, false).await.unwrap();
     });
     (addr, handle)
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -4,15 +4,20 @@ use renews::config::Config;
 fn retention_rules_match() {
     let toml = r#"port = 1199
 default_retention_days = 10
-[[retention]]
+default_max_article_bytes = "1K"
+[[group_settings]]
 pattern = "foo.*"
-days = 1
-[[retention]]
+retention_days = 1
+[[group_settings]]
 group = "foo.bar"
-days = 5
+retention_days = 5
+max_article_bytes = "20K"
 "#;
     let cfg: Config = toml::from_str(toml).unwrap();
     assert_eq!(cfg.retention_for_group("misc").unwrap().num_days(), 10);
     assert_eq!(cfg.retention_for_group("foo.test").unwrap().num_days(), 1);
     assert_eq!(cfg.retention_for_group("foo.bar").unwrap().num_days(), 5);
+    assert_eq!(cfg.max_size_for_group("misc"), Some(1024));
+    assert_eq!(cfg.max_size_for_group("foo.test"), Some(1024));
+    assert_eq!(cfg.max_size_for_group("foo.bar"), Some(20480));
 }

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -1,0 +1,50 @@
+use renews::config::Config;
+use renews::storage::{Storage, sqlite::SqliteStorage};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+mod common;
+
+#[tokio::test]
+async fn ihave_rejects_large_article() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc.test").await.unwrap();
+    let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap();
+    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), cfg).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"IHAVE <1@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("335"));
+    line.clear();
+    let article = "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\n0123456789A\r\n.\r\n";
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("437"));
+}
+
+#[tokio::test]
+async fn ihave_rejects_large_article_with_suffix() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc.test").await.unwrap();
+    let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap();
+    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), cfg).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"IHAVE <2@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("335"));
+    line.clear();
+    let body = "A".repeat(1100);
+    let article = format!(
+        "Message-ID: <2@test>\r\nNewsgroups: misc.test\r\n\r\n{}\r\n.\r\n",
+        body
+    );
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("437"));
+}


### PR DESCRIPTION
## Summary
- allow specifying per-group configuration
- add max article size limits that can be overridden per-group or pattern
- enforce article size limits on POST, IHAVE and TAKETHIS
- accept max size values with K/M/G suffixes
- update docs and example config
- test the new config parsing and enforcement

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686674526bc883268f98b3d9023fa2ce