### PR TITLE
Add AUTHINFO command with login requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -983,6 +1004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,10 +1159,12 @@ dependencies = [
 name = "renews"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "async-trait",
  "chrono",
  "clap",
  "nom",
+ "rand_core",
  "rustls-pemfile",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ chrono = { version = "0.4", default-features = false, features = ["alloc", "cloc
 tokio-rustls = "0.24"
 rustls-pemfile = "1"
 clap = { version = "4", features = ["derive"] }
+argon2 = { version = "0.5", features = ["std"] }
+rand_core = { version = "0.6", features = ["std", "getrandom"] }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ following keys are recognised:
 - `port` - TCP port for plain NNTP connections.
 - `groups` - list of newsgroups that will be created on start-up.
 - `db_path` - path to the SQLite database file. Defaults to `/var/spool/renews.db`.
+- `auth_db_path` - optional path to the authentication database. Defaults to `db_path` when unset.
 - `tls_port` - optional port for NNTP over TLS.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
@@ -35,6 +36,7 @@ An example configuration is provided in the repository:
 port = 1199
 groups = ["misc.news"]
 db_path = "/var/spool/renews.db"
+auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 port = 1199
 groups = ["misc.news"]
 db_path = "/var/spool/renews.db"
+auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,68 @@
+use async_trait::async_trait;
+use std::error::Error;
+use std::sync::Arc;
+
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    async fn add_user(&self, username: &str, password: &str) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn verify_user(&self, username: &str, password: &str) -> Result<bool, Box<dyn Error + Send + Sync>>;
+}
+
+pub type DynAuth = Arc<dyn AuthProvider>;
+
+pub mod sqlite {
+    use super::*;
+    use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+    use argon2::password_hash::{SaltString, rand_core::OsRng};
+    use sqlx::{Row, SqlitePool, sqlite::SqlitePoolOptions};
+
+    #[derive(Clone)]
+    pub struct SqliteAuth {
+        pool: SqlitePool,
+    }
+
+    impl SqliteAuth {
+        pub async fn new(path: &str) -> Result<Self, Box<dyn Error + Send + Sync>> {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(5)
+                .connect(path)
+                .await?;
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS users (\n                    username TEXT PRIMARY KEY,\n                    password_hash TEXT NOT NULL\n                )",
+            )
+            .execute(&pool)
+            .await?;
+            Ok(Self { pool })
+        }
+    }
+
+    #[async_trait]
+    impl AuthProvider for SqliteAuth {
+        async fn add_user(&self, username: &str, password: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+            let salt = SaltString::generate(&mut OsRng);
+            let hash = Argon2::default()
+                .hash_password(password.as_bytes(), &salt)?
+                .to_string();
+            sqlx::query("INSERT OR REPLACE INTO users (username, password_hash) VALUES (?, ?)")
+                .bind(username)
+                .bind(hash)
+                .execute(&self.pool)
+                .await?;
+            Ok(())
+        }
+
+        async fn verify_user(&self, username: &str, password: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
+            if let Some(row) = sqlx::query("SELECT password_hash FROM users WHERE username = ?")
+                .bind(username)
+                .fetch_optional(&self.pool)
+                .await? {
+                let stored: String = row.get(0);
+                let parsed = PasswordHash::new(&stored)?;
+                Ok(Argon2::default().verify_password(password.as_bytes(), &parsed).is_ok())
+            } else {
+                Ok(false)
+            }
+        }
+    }
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,8 @@ pub struct Config {
     #[serde(default = "default_db_path")]
     pub db_path: String,
     #[serde(default)]
+    pub auth_db_path: Option<String>,
+    #[serde(default)]
     pub tls_port: Option<u16>,
     #[serde(default)]
     pub tls_cert: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use renews::config::Config;
 use renews::retention::cleanup_expired_articles;
 use renews::storage::Storage;
 use renews::storage::sqlite::SqliteStorage;
+use renews::auth::{AuthProvider, sqlite::SqliteAuth};
 
 #[derive(Parser)]
 struct Args {
@@ -48,20 +49,25 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cfg = Config::from_file(&args.config)?;
     let db_conn = format!("sqlite:{}", cfg.db_path);
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&db_conn).await?);
+    let auth_path = cfg.auth_db_path.as_deref().unwrap_or(&cfg.db_path);
+    let auth_conn = format!("sqlite:{}", auth_path);
+    let auth: Arc<dyn AuthProvider> = Arc::new(SqliteAuth::new(&auth_conn).await?);
     for g in &cfg.groups {
         storage.add_group(g).await?;
     }
     let addr = format!("127.0.0.1:{}", cfg.port);
     let listener = TcpListener::bind(&addr).await?;
     let storage_clone = storage.clone();
+    let auth_clone = auth.clone();
     let cfg_clone = cfg.clone();
     tokio::spawn(async move {
         loop {
             let (socket, _) = listener.accept().await.unwrap();
             let st = storage_clone.clone();
+            let au = auth_clone.clone();
             let cfg = cfg_clone.clone();
             tokio::spawn(async move {
-                if let Err(e) = renews::handle_client(socket, st, cfg, false).await {
+                if let Err(e) = renews::handle_client(socket, st, au, cfg, false).await {
                     eprintln!("client error: {e}");
                 }
             });
@@ -75,17 +81,19 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let tls_listener = TcpListener::bind(&tls_addr).await?;
         let tls_config = TlsAcceptor::from(Arc::new(load_tls_config(cert, key)?));
         let storage_clone = storage.clone();
+        let auth_clone = auth.clone();
         let cfg_clone = cfg.clone();
         tokio::spawn(async move {
             loop {
                 let (socket, _) = tls_listener.accept().await.unwrap();
                 let acceptor = tls_config.clone();
                 let st = storage_clone.clone();
+                let au = auth_clone.clone();
                 let cfg = cfg_clone.clone();
                 tokio::spawn(async move {
                     match acceptor.accept(socket).await {
                         Ok(stream) => {
-                            if let Err(e) = renews::handle_client(stream, st, cfg, true).await {
+                            if let Err(e) = renews::handle_client(stream, st, au, cfg, true).await {
                                 eprintln!("client error: {e}");
                             }
                         }

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -9,11 +9,12 @@ mod common;
 #[tokio::test]
 async fn head_and_list_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: T\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -69,13 +70,14 @@ async fn head_and_list_commands() {
 #[tokio::test]
 async fn listgroup_and_navigation_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc", &m1).await.unwrap();
     storage.store_article("misc", &m2).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -207,9 +209,10 @@ async fn listgroup_and_navigation_commands() {
 #[tokio::test]
 async fn capabilities_and_misc_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -284,11 +287,12 @@ async fn capabilities_and_misc_commands() {
 #[tokio::test]
 async fn no_group_returns_412() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -312,11 +316,12 @@ async fn no_group_returns_412() {
 #[tokio::test]
 async fn responses_include_number_and_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -380,9 +385,10 @@ async fn responses_include_number_and_id() {
 #[tokio::test]
 async fn post_and_dot_stuffing() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -417,11 +423,12 @@ async fn post_and_dot_stuffing() {
 #[tokio::test]
 async fn body_returns_proper_crlf() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nline1\r\nline2\r\n").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut buf = Vec::new();
 
@@ -454,9 +461,10 @@ async fn body_returns_proper_crlf() {
 #[tokio::test]
 async fn newgroups_accepts_gmt_argument() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -491,11 +499,12 @@ async fn newgroups_accepts_gmt_argument() {
 #[tokio::test]
 async fn newnews_accepts_gmt_argument() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 
@@ -528,9 +537,10 @@ async fn newnews_accepts_gmt_argument() {
 #[tokio::test]
 async fn post_without_selecting_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc").await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
     let mut line = String::new();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use renews::handle_client;
 use renews::storage::Storage;
+use renews::auth::AuthProvider;
 use renews::config::Config;
 use std::sync::Arc;
 use tokio::io::BufReader;
@@ -7,28 +8,32 @@ use tokio::net::{TcpListener, TcpStream};
 
 pub async fn setup_server(
     storage: Arc<dyn Storage>,
+    auth: Arc<dyn AuthProvider>,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
+    let auth_clone = auth.clone();
     let cfg: Config = toml::from_str("port=1199").unwrap();
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone, cfg, false).await.unwrap();
+        handle_client(sock, store_clone, auth_clone, cfg, false).await.unwrap();
     });
     (addr, handle)
 }
 
 pub async fn setup_server_with_cfg(
     storage: Arc<dyn Storage>,
+    auth: Arc<dyn AuthProvider>,
     cfg: Config,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
+    let auth_clone = auth.clone();
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone, cfg, false).await.unwrap();
+        handle_client(sock, store_clone, auth_clone, cfg, false).await.unwrap();
     });
     (addr, handle)
 }

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -8,9 +8,10 @@ mod common;
 #[tokio::test]
 async fn ihave_rejects_large_article() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap();
-    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), cfg).await;
+    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -28,9 +29,10 @@ async fn ihave_rejects_large_article() {
 #[tokio::test]
 async fn ihave_rejects_large_article_with_suffix() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap();
-    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), cfg).await;
+    let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -8,7 +8,8 @@ mod common;
 #[tokio::test]
 async fn unknown_command_mail() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -21,7 +22,8 @@ async fn unknown_command_mail() {
 #[tokio::test]
 async fn capabilities_and_unknown_command() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -55,7 +57,8 @@ async fn capabilities_and_unknown_command() {
 #[tokio::test]
 async fn unsupported_mode_variant() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -68,7 +71,8 @@ async fn unsupported_mode_variant() {
 #[tokio::test]
 async fn article_syntax_error() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -84,7 +88,8 @@ async fn article_syntax_error() {
 #[tokio::test]
 async fn head_without_group_returns_412() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -97,7 +102,8 @@ async fn head_without_group_returns_412() {
 #[tokio::test]
 async fn list_unknown_keyword() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -110,7 +116,8 @@ async fn list_unknown_keyword() {
 #[tokio::test]
 async fn unknown_command_xencrypt() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -126,7 +133,8 @@ async fn unknown_command_xencrypt() {
 #[tokio::test]
 async fn mode_reader_success() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -139,7 +147,8 @@ async fn mode_reader_success() {
 #[tokio::test]
 async fn commands_are_case_insensitive() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -156,8 +165,9 @@ async fn commands_are_case_insensitive() {
 #[tokio::test]
 async fn group_select_returns_211() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -170,10 +180,11 @@ async fn group_select_returns_211() {
 #[tokio::test]
 async fn article_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -193,10 +204,11 @@ async fn article_success_by_number() {
 #[tokio::test]
 async fn article_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -213,8 +225,9 @@ async fn article_success_by_id() {
 #[tokio::test]
 async fn article_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -227,7 +240,8 @@ async fn article_id_not_found() {
 #[tokio::test]
 async fn article_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -240,10 +254,11 @@ async fn article_number_no_group() {
 #[tokio::test]
 async fn head_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -263,10 +278,11 @@ async fn head_success_by_number() {
 #[tokio::test]
 async fn head_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -283,10 +299,11 @@ async fn head_success_by_id() {
 #[tokio::test]
 async fn head_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -302,8 +319,9 @@ async fn head_number_not_found() {
 #[tokio::test]
 async fn head_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -316,8 +334,9 @@ async fn head_id_not_found() {
 #[tokio::test]
 async fn head_no_current_article_selected() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -333,10 +352,11 @@ async fn head_no_current_article_selected() {
 #[tokio::test]
 async fn body_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -356,10 +376,11 @@ async fn body_success_by_number() {
 #[tokio::test]
 async fn body_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -376,10 +397,11 @@ async fn body_success_by_id() {
 #[tokio::test]
 async fn body_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -395,8 +417,9 @@ async fn body_number_not_found() {
 #[tokio::test]
 async fn body_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -409,7 +432,8 @@ async fn body_id_not_found() {
 #[tokio::test]
 async fn body_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -422,10 +446,11 @@ async fn body_number_no_group() {
 #[tokio::test]
 async fn stat_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -441,10 +466,11 @@ async fn stat_success_by_number() {
 #[tokio::test]
 async fn stat_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -457,10 +483,11 @@ async fn stat_success_by_id() {
 #[tokio::test]
 async fn stat_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -476,8 +503,9 @@ async fn stat_number_not_found() {
 #[tokio::test]
 async fn stat_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -490,7 +518,8 @@ async fn stat_id_not_found() {
 #[tokio::test]
 async fn stat_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -503,10 +532,11 @@ async fn stat_number_no_group() {
 #[tokio::test]
 async fn listgroup_returns_numbers() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -530,7 +560,8 @@ async fn listgroup_returns_numbers() {
 #[tokio::test]
 async fn listgroup_without_group_selected() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let (addr, _h) = common::setup_server(storage).await;
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -543,9 +574,10 @@ async fn listgroup_without_group_selected() {
 #[tokio::test]
 async fn list_newsgroups_returns_groups() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     storage.add_group("alt.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -571,8 +603,9 @@ async fn list_newsgroups_returns_groups() {
 #[tokio::test]
 async fn list_all_keywords() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -638,10 +671,11 @@ async fn list_all_keywords() {
 #[tokio::test]
 async fn newnews_lists_recent_articles() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -668,10 +702,11 @@ async fn newnews_lists_recent_articles() {
 #[tokio::test]
 async fn newnews_no_matches_returns_empty() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -702,10 +737,11 @@ async fn newnews_no_matches_returns_empty() {
 #[tokio::test]
 async fn hdr_subject_by_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -724,12 +760,13 @@ async fn hdr_subject_by_message_id() {
 #[tokio::test]
 async fn hdr_subject_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: A\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: B\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -756,13 +793,14 @@ async fn hdr_subject_range() {
 #[tokio::test]
 async fn hdr_all_headers_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message(
         "Message-ID: <1@test>\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody",
     )
     .unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -788,10 +826,11 @@ async fn hdr_all_headers_message_id() {
 #[tokio::test]
 async fn xpat_subject_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -810,12 +849,13 @@ async fn xpat_subject_message_id() {
 #[tokio::test]
 async fn xpat_subject_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: apple\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: banana\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -842,11 +882,12 @@ async fn xpat_subject_range() {
 #[tokio::test]
 async fn over_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -869,6 +910,7 @@ async fn over_message_id() {
 #[tokio::test]
 async fn over_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
@@ -876,7 +918,7 @@ async fn over_range() {
         parse_message("Message-ID: <2@test>\r\nSubject: B\r\nFrom: b@test\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -903,12 +945,13 @@ async fn over_range() {
 #[tokio::test]
 async fn head_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -934,12 +977,13 @@ async fn head_range() {
 #[tokio::test]
 async fn body_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -965,12 +1009,13 @@ async fn body_range() {
 #[tokio::test]
 async fn article_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
     storage.store_article("misc.test", &m2).await.unwrap();
-    let (addr, _h) = common::setup_server(storage).await;
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -996,9 +1041,10 @@ async fn article_range() {
 #[tokio::test]
 async fn ihave_example() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -1039,6 +1085,7 @@ async fn ihave_example() {
 #[tokio::test]
 async fn takethis_example() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc.test").await.unwrap();
     let (_, exist) = parse_message(
         "Message-ID: <i.am.an.article.you.have@example.com>\r\nNewsgroups: misc.test\r\n\r\nBody",
@@ -1046,7 +1093,7 @@ async fn takethis_example() {
     .unwrap();
     storage.store_article("misc.test", &exist).await.unwrap();
 
-    let (addr, _h) = common::setup_server(storage.clone()).await;
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();


### PR DESCRIPTION
## Summary
- add new `AuthProvider` trait with SQLite implementation using hashed passwords
- support `AUTHINFO USER/PASS` over TLS only
- require authentication for posting
- wire authentication into server setup
- adjust tests for new authentication requirements
- add `auth_db_path` config option for specifying separate auth database

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6866c2cf20c88326998fa3f41d324063