### PR TITLE
Add TLS integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -930,6 +945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1113,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1147,6 +1184,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "218a7fbb357f6da42c9fd3610b1a5128d087d460e5386eaa5040705c464611dc"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1215,7 @@ dependencies = [
  "clap",
  "nom",
  "rand_core",
+ "rcgen",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1245,7 +1296,16 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -1525,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags",
  "byteorder",
  "bytes",
@@ -1567,7 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags",
  "byteorder",
  "crc",
@@ -1715,6 +1775,25 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -2354,6 +2433,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ rustls-pemfile = "1"
 clap = { version = "4", features = ["derive"] }
 argon2 = { version = "0.5", features = ["std"] }
 rand_core = { version = "0.6", features = ["std", "getrandom"] }
+
+[dev-dependencies]
+rcgen = "0.14"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,6 +5,9 @@ use renews::config::Config;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::{TlsAcceptor, TlsConnector, rustls};
+use tokio::io::{self, ReadHalf, WriteHalf};
+use rcgen::{generate_simple_self_signed, CertifiedKey};
 
 pub async fn setup_server(
     storage: Arc<dyn Storage>,
@@ -46,5 +49,59 @@ pub async fn connect(
 ) {
     let stream = TcpStream::connect(addr).await.unwrap();
     let (r, w) = stream.into_split();
+    (BufReader::new(r), w)
+}
+
+pub async fn setup_tls_server(
+    storage: Arc<dyn Storage>,
+    auth: Arc<dyn AuthProvider>,
+) -> (
+    std::net::SocketAddr,
+    rustls::Certificate,
+    tokio::task::JoinHandle<()>,
+) {
+    let CertifiedKey { cert, signing_key } =
+        generate_simple_self_signed(["localhost".to_string()]).unwrap();
+    let cert_der = cert.der().to_vec();
+    let key = signing_key.serialize_der();
+    let tls_config = rustls::ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(vec![rustls::Certificate(cert_der.clone())], rustls::PrivateKey(key))
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let store_clone = storage.clone();
+    let auth_clone = auth.clone();
+    let cfg: Config = toml::from_str("port=1199").unwrap();
+    let handle = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let stream = acceptor.accept(sock).await.unwrap();
+        handle_client(stream, store_clone, auth_clone, cfg, true)
+            .await
+            .unwrap();
+    });
+    (addr, rustls::Certificate(cert_der), handle)
+}
+
+pub async fn connect_tls(
+    addr: std::net::SocketAddr,
+    cert: rustls::Certificate,
+) -> (
+    BufReader<ReadHalf<tokio_rustls::client::TlsStream<TcpStream>>>,
+    WriteHalf<tokio_rustls::client::TlsStream<TcpStream>>,
+) {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(&cert).unwrap();
+    let config = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(config));
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let server_name = rustls::ServerName::try_from("localhost").unwrap();
+    let tls_stream = connector.connect(server_name, stream).await.unwrap();
+    let (r, w) = io::split(tls_stream);
     (BufReader::new(r), w)
 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,103 @@
+use renews::storage::{Storage, sqlite::SqliteStorage};
+use renews::auth::AuthProvider;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+mod common;
+
+#[tokio::test]
+async fn tls_quit() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, cert, _h) = common::setup_tls_server(storage, auth).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("200"));
+    line.clear();
+    writer.write_all(b"QUIT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("205"));
+}
+
+#[tokio::test]
+async fn tls_mode_reader() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, cert, _h) = common::setup_tls_server(storage, auth).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("200"));
+}
+
+#[tokio::test]
+async fn tls_post_requires_auth() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"GROUP misc\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"POST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("480"));
+    assert!(storage.get_article_by_id("<post@test>").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn tls_authinfo_and_post() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO USER user\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("381"));
+    line.clear();
+    writer.write_all(b"AUTHINFO PASS pass\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("281"));
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"GROUP misc\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"POST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("340"));
+    line.clear();
+    let article = concat!(
+        "Message-ID: <post@test>\r\n",
+        "Newsgroups: misc\r\n",
+        "\r\n",
+        "Body\r\n",
+        ".\r\n",
+    );
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("240"));
+    assert!(storage.get_article_by_id("<post@test>").await.unwrap().is_some());
+    line.clear();
+    writer.write_all(b"QUIT\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("205"));
+}


### PR DESCRIPTION
## Summary
- add `rcgen` dev-dependency
- create helper functions for TLS in `tests/common`
- implement integration tests using a self-signed certificate
- add POST and AUTHINFO coverage over TLS

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6866cbdf8c5c8326920c3436c70bfd65