### PR TITLE
Use TAB separator in OVER response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,7 +932,7 @@ async fn handle_over<W: AsyncWrite + Unpin>(
         writer
             .write_all(
                 format!(
-                    "{}|{}|{}|{}|{}|{}|{}|{}\r\n",
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\r\n",
                     num, subject, from, date, msgid, refs, bytes, lines
                 )
                 .as_bytes(),

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -897,7 +897,7 @@ async fn over_message_id() {
     assert!(line.starts_with("224"));
     line.clear();
     reader.read_line(&mut line).await.unwrap();
-    assert!(line.starts_with("0|"));
+    assert!(line.starts_with("0\t"));
     loop {
         line.clear();
         reader.read_line(&mut line).await.unwrap();


### PR DESCRIPTION
## Summary
- follow RFC 3977 recommendation for OVER output and separate fields using TAB
- update integration test to expect the TAB delimiter

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68670bd54ee083269e3b127614654ae4