### PR TITLE
Handle LIST DISTRIB.PATS as unsupported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ const RESP_501_MSGID_REQUIRED: &str = "501 message-id required\r\n";
 const RESP_500_UNKNOWN_CMD: &str = "500 command not recognized\r\n";
 const RESP_500_SYNTAX: &str = "500 syntax error\r\n";
 const RESP_503_DATA_NOT_STORED: &str = "503 Data item not stored\r\n";
+const RESP_503_NOT_SUPPORTED: &str = "503 feature not supported\r\n";
 const RESP_224_OVERVIEW: &str = "224 Overview information follows\r\n";
 const RESP_225_HEADERS: &str = "225 Headers follow\r\n";
 const RESP_221_HEADER_FOLLOWS: &str = "221 Header follows\r\n";
@@ -533,7 +534,11 @@ async fn handle_list<W: AsyncWrite + Unpin>(
                 writer.write_all(RESP_DOT_CRLF.as_bytes()).await?;
                 return Ok(());
             }
-            // DISTRIB.PATS is intentionally unimplemented and falls through here.
+            "DISTRIB.PATS" => {
+                writer.write_all(RESP_503_NOT_SUPPORTED.as_bytes()).await?;
+                return Ok(());
+            }
+            // Other keywords are not recognised
             _ => {
                 writer
                     .write_all(RESP_501_UNKNOWN_KEYWORD.as_bytes())

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -114,6 +114,20 @@ async fn list_unknown_keyword() {
 }
 
 #[tokio::test]
+async fn list_distrib_pats_not_supported() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let (addr, _h) = common::setup_server(storage, auth.clone()).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"LIST DISTRIB.PATS\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("503"));
+}
+
+#[tokio::test]
 async fn unknown_command_xencrypt() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());


### PR DESCRIPTION
## Summary
- return a `503 feature not supported` response for `LIST DISTRIB.PATS`
- add regression test for the new behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68670c2a45688326b1ebfdcd4a3bfd83