### PR TITLE
Add env override for config path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ toml = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
 tokio-rustls = "0.24"
 rustls-pemfile = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 argon2 = { version = "0.5", features = ["std"] }
 rand_core = { version = "0.6", features = ["std", "getrandom"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This produces the `renews` binary in `target/release/`.
 
 ## Configuration
 
-Configuration is loaded from the file specified with `--config` (defaults to
-`/etc/renews.toml`). The
+Configuration is loaded from the file specified with `--config`. When the
+`RENEWS_CONFIG` environment variable is set it is used as the default,
+otherwise `/etc/renews.toml` is assumed. The
 following keys are recognised:
 
 - `port` - TCP port for plain NNTP connections.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use renews::storage::sqlite::SqliteStorage;
 #[derive(Parser)]
 struct Args {
     /// Path to the configuration file
-    #[arg(long, default_value = "/etc/renews.toml")]
+    #[arg(long, env = "RENEWS_CONFIG", default_value = "/etc/renews.toml")]
     config: String,
 }
 


### PR DESCRIPTION
## Summary
- allow specifying the config file path via the `RENEWS_CONFIG` environment variable
- document the `RENEWS_CONFIG` variable
- enable clap's `env` feature

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867136cb3ec8326b5a7957755e0c776