### PR TITLE
Implement CHECK and streaming support

### DIFF
--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -8,7 +8,11 @@ mod common;
 #[tokio::test]
 async fn unknown_command_mail() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -22,7 +26,11 @@ async fn unknown_command_mail() {
 #[tokio::test]
 async fn capabilities_and_unknown_command() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -57,7 +65,11 @@ async fn capabilities_and_unknown_command() {
 #[tokio::test]
 async fn unsupported_mode_variant() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -71,7 +83,11 @@ async fn unsupported_mode_variant() {
 #[tokio::test]
 async fn article_syntax_error() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -88,7 +104,11 @@ async fn article_syntax_error() {
 #[tokio::test]
 async fn head_without_group_returns_412() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -102,7 +122,11 @@ async fn head_without_group_returns_412() {
 #[tokio::test]
 async fn list_unknown_keyword() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -116,7 +140,11 @@ async fn list_unknown_keyword() {
 #[tokio::test]
 async fn list_distrib_pats_not_supported() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -130,7 +158,11 @@ async fn list_distrib_pats_not_supported() {
 #[tokio::test]
 async fn unknown_command_xencrypt() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -147,7 +179,11 @@ async fn unknown_command_xencrypt() {
 #[tokio::test]
 async fn mode_reader_success() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -161,7 +197,11 @@ async fn mode_reader_success() {
 #[tokio::test]
 async fn commands_are_case_insensitive() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -179,7 +219,11 @@ async fn commands_are_case_insensitive() {
 #[tokio::test]
 async fn group_select_returns_211() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -194,7 +238,11 @@ async fn group_select_returns_211() {
 #[tokio::test]
 async fn article_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -218,7 +266,11 @@ async fn article_success_by_number() {
 #[tokio::test]
 async fn article_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -239,7 +291,11 @@ async fn article_success_by_id() {
 #[tokio::test]
 async fn article_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -254,7 +310,11 @@ async fn article_id_not_found() {
 #[tokio::test]
 async fn article_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -268,7 +328,11 @@ async fn article_number_no_group() {
 #[tokio::test]
 async fn head_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -292,7 +356,11 @@ async fn head_success_by_number() {
 #[tokio::test]
 async fn head_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -313,7 +381,11 @@ async fn head_success_by_id() {
 #[tokio::test]
 async fn head_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -333,7 +405,11 @@ async fn head_number_not_found() {
 #[tokio::test]
 async fn head_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -348,7 +424,11 @@ async fn head_id_not_found() {
 #[tokio::test]
 async fn head_no_current_article_selected() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -366,7 +446,11 @@ async fn head_no_current_article_selected() {
 #[tokio::test]
 async fn body_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -390,7 +474,11 @@ async fn body_success_by_number() {
 #[tokio::test]
 async fn body_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -411,7 +499,11 @@ async fn body_success_by_id() {
 #[tokio::test]
 async fn body_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -431,7 +523,11 @@ async fn body_number_not_found() {
 #[tokio::test]
 async fn body_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -446,7 +542,11 @@ async fn body_id_not_found() {
 #[tokio::test]
 async fn body_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -460,7 +560,11 @@ async fn body_number_no_group() {
 #[tokio::test]
 async fn stat_success_by_number() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -480,7 +584,11 @@ async fn stat_success_by_number() {
 #[tokio::test]
 async fn stat_success_by_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -497,7 +605,11 @@ async fn stat_success_by_id() {
 #[tokio::test]
 async fn stat_number_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -517,7 +629,11 @@ async fn stat_number_not_found() {
 #[tokio::test]
 async fn stat_id_not_found() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -532,7 +648,11 @@ async fn stat_id_not_found() {
 #[tokio::test]
 async fn stat_number_no_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -546,7 +666,11 @@ async fn stat_number_no_group() {
 #[tokio::test]
 async fn listgroup_returns_numbers() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -574,7 +698,11 @@ async fn listgroup_returns_numbers() {
 #[tokio::test]
 async fn listgroup_without_group_selected() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -588,7 +716,11 @@ async fn listgroup_without_group_selected() {
 #[tokio::test]
 async fn list_newsgroups_returns_groups() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     storage.add_group("alt.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -617,7 +749,11 @@ async fn list_newsgroups_returns_groups() {
 #[tokio::test]
 async fn list_all_keywords() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -633,8 +769,12 @@ async fn list_all_keywords() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
-        if trimmed.starts_with("misc.test") { found = true; }
+        if trimmed == "." {
+            break;
+        }
+        if trimmed.starts_with("misc.test") {
+            found = true;
+        }
     }
     assert!(found);
     line.clear();
@@ -647,12 +787,15 @@ async fn list_all_keywords() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
-        if trimmed.starts_with("misc.test") { found = true; }
+        if trimmed == "." {
+            break;
+        }
+        if trimmed.starts_with("misc.test") {
+            found = true;
+        }
     }
     assert!(found);
     line.clear();
-
 
     writer.write_all(b"LIST OVERVIEW.FMT\r\n").await.unwrap();
     reader.read_line(&mut line).await.unwrap();
@@ -662,8 +805,12 @@ async fn list_all_keywords() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
-        if trimmed == "Subject:" { has_subject = true; }
+        if trimmed == "." {
+            break;
+        }
+        if trimmed == "Subject:" {
+            has_subject = true;
+        }
     }
     assert!(has_subject);
     line.clear();
@@ -676,8 +823,12 @@ async fn list_all_keywords() {
         line.clear();
         reader.read_line(&mut line).await.unwrap();
         let trimmed = line.trim_end();
-        if trimmed == "." { break; }
-        if trimmed == ":" { has_colon = true; }
+        if trimmed == "." {
+            break;
+        }
+        if trimmed == ":" {
+            has_colon = true;
+        }
     }
     assert!(has_colon);
 }
@@ -685,7 +836,11 @@ async fn list_all_keywords() {
 #[tokio::test]
 async fn newnews_lists_recent_articles() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -716,7 +871,11 @@ async fn newnews_lists_recent_articles() {
 #[tokio::test]
 async fn newnews_no_matches_returns_empty() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -751,7 +910,11 @@ async fn newnews_no_matches_returns_empty() {
 #[tokio::test]
 async fn hdr_subject_by_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -774,7 +937,11 @@ async fn hdr_subject_by_message_id() {
 #[tokio::test]
 async fn hdr_subject_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: A\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: B\r\n\r\nBody").unwrap();
@@ -807,12 +974,15 @@ async fn hdr_subject_range() {
 #[tokio::test]
 async fn hdr_all_headers_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
-    let (_, msg) = parse_message(
-        "Message-ID: <1@test>\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody",
-    )
-    .unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody")
+            .unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -840,7 +1010,11 @@ async fn hdr_all_headers_message_id() {
 #[tokio::test]
 async fn xpat_subject_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -849,7 +1023,10 @@ async fn xpat_subject_message_id() {
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
     line.clear();
-    writer.write_all(b"XPAT Subject <1@test> *ell*\r\n").await.unwrap();
+    writer
+        .write_all(b"XPAT Subject <1@test> *ell*\r\n")
+        .await
+        .unwrap();
     reader.read_line(&mut line).await.unwrap();
     assert!(line.starts_with("221"));
     line.clear();
@@ -863,7 +1040,11 @@ async fn xpat_subject_message_id() {
 #[tokio::test]
 async fn xpat_subject_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: apple\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: banana\r\n\r\nBody").unwrap();
@@ -896,7 +1077,11 @@ async fn xpat_subject_range() {
 #[tokio::test]
 async fn over_message_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, msg) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
@@ -924,7 +1109,11 @@ async fn over_message_id() {
 #[tokio::test]
 async fn over_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
@@ -959,7 +1148,11 @@ async fn over_range() {
 #[tokio::test]
 async fn head_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
@@ -991,7 +1184,11 @@ async fn head_range() {
 #[tokio::test]
 async fn body_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
@@ -1023,7 +1220,11 @@ async fn body_range() {
 #[tokio::test]
 async fn article_range() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
@@ -1055,7 +1256,11 @@ async fn article_range() {
 #[tokio::test]
 async fn ihave_example() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
@@ -1099,7 +1304,11 @@ async fn ihave_example() {
 #[tokio::test]
 async fn takethis_example() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
     storage.add_group("misc.test").await.unwrap();
     let (_, exist) = parse_message(
         "Message-ID: <i.am.an.article.you.have@example.com>\r\nNewsgroups: misc.test\r\n\r\nBody",
@@ -1147,4 +1356,70 @@ async fn takethis_example() {
     writer.write_all(take_reject.as_bytes()).await.unwrap();
     reader.read_line(&mut line).await.unwrap();
     assert!(line.starts_with("439"));
+}
+
+#[tokio::test]
+async fn mode_stream_check_and_takethis() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc.test").await.unwrap();
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    writer.write_all(b"MODE STREAM\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("203"));
+    line.clear();
+
+    writer.write_all(b"CHECK <stream1@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("238"));
+    line.clear();
+
+    writer.write_all(b"CHECK <stream2@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("238"));
+    line.clear();
+
+    let art1 = concat!(
+        "TAKETHIS <stream1@test>\r\n",
+        "Newsgroups: misc.test\r\n",
+        "Message-ID: <stream1@test>\r\n",
+        "\r\n",
+        "Body one\r\n",
+        ".\r\n",
+    );
+    writer.write_all(art1.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("239"));
+    line.clear();
+
+    let art2 = concat!(
+        "TAKETHIS <stream2@test>\r\n",
+        "Newsgroups: misc.test\r\n",
+        "Message-ID: <stream2@test>\r\n",
+        "\r\n",
+        "Body two\r\n",
+        ".\r\n",
+    );
+    writer.write_all(art2.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("239"));
+    line.clear();
+
+    writer.write_all(b"CHECK <stream1@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("438"));
+    line.clear();
+
+    writer.write_all(b"CHECK <stream2@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("438"));
 }


### PR DESCRIPTION
## Summary
- implement CHECK command from RFC 4644
- add MODE STREAM support
- document new commands in HELP text
- test MODE STREAM workflow using CHECK and TAKETHIS
- update test to use CHECK for two message-ids before sending

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_686711e6aa6083268d143331fbb6cafa