### PR TITLE
Remove groups setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ otherwise `/etc/renews.toml` is assumed. The
 following keys are recognised:
 
 - `port` - TCP port for plain NNTP connections.
-- `groups` - list of newsgroups that will be created on start-up.
 - `db_path` - path to the SQLite database file. Defaults to `/var/spool/renews.db`.
 - `auth_db_path` - optional path to the authentication database. Defaults to `db_path` when unset.
 - `tls_port` - optional port for NNTP over TLS.
@@ -35,7 +34,6 @@ An example configuration is provided in the repository:
 
 ```toml
 port = 1199
-groups = ["misc.news"]
 db_path = "/var/spool/renews.db"
 auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,4 @@
 port = 1199
-groups = ["misc.news"]
 db_path = "/var/spool/renews.db"
 auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,8 +80,6 @@ where
 #[derive(Deserialize, Clone)]
 pub struct Config {
     pub port: u16,
-    #[serde(default)]
-    pub groups: Vec<String>,
     #[serde(default = "default_db_path")]
     pub db_path: String,
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let auth_path = cfg.auth_db_path.as_deref().unwrap_or(&cfg.db_path);
     let auth_conn = format!("sqlite:{}", auth_path);
     let auth: Arc<dyn AuthProvider> = Arc::new(SqliteAuth::new(&auth_conn).await?);
-    for g in &cfg.groups {
-        storage.add_group(g).await?;
-    }
     let addr = format!("127.0.0.1:{}", cfg.port);
     info!("listening on {addr}");
     let listener = TcpListener::bind(&addr).await?;


### PR DESCRIPTION
## Summary
- drop `groups` from config definition
- remove startup group creation logic
- update example configuration and docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686718d1357c8326b15cbb55b1021d00