### PR TITLE
Implement Message-ID escaping/unescaping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1222,6 +1222,7 @@ where
         }
     };
     ensure_message_id(&mut message);
+    parse::escape_message_id_header(&mut message);
     let newsgroups = match message
         .headers
         .iter()
@@ -1309,6 +1310,7 @@ where
             }
         };
         ensure_message_id(&mut article);
+        parse::escape_message_id_header(&mut article);
         let newsgroups = article
             .headers
             .iter()
@@ -1402,6 +1404,7 @@ where
             }
         };
         ensure_message_id(&mut article);
+        parse::escape_message_id_header(&mut article);
         let newsgroups = article
             .headers
             .iter()


### PR DESCRIPTION
## Summary
- support RFC 2822 quoted-pair unescaping when parsing `Message-ID`
- provide helpers to escape/unescape message IDs
- escape message IDs when posting articles
- test the escape/unescape round trip

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68671c26fe708326aaac86fa329ba4c2