### PR TITLE
Add admin management

### DIFF
--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,0 +1,12 @@
+use renews::auth::{AuthProvider, sqlite::SqliteAuth};
+
+#[tokio::test]
+async fn add_and_check_admin() {
+    let auth = SqliteAuth::new("sqlite::memory:").await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    assert!(!auth.is_admin("user").await.unwrap());
+    auth.add_admin("user").await.unwrap();
+    assert!(auth.is_admin("user").await.unwrap());
+    auth.remove_admin("user").await.unwrap();
+    assert!(!auth.is_admin("user").await.unwrap());
+}


### PR DESCRIPTION
## Summary
- extend `AuthProvider` with admin methods
- store admins in a new table for SQLite auth
- use a foreign key from `admins.username` to `users.username`
- test admin helpers

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68671c88602c83269eae737d5d37c736