### PR TITLE
Add Date header automatically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use parse::{
     Message,
     Response,
     ensure_message_id,
+    ensure_date,
     parse_command,
     parse_datetime,
     parse_message,
@@ -1222,6 +1223,7 @@ where
         }
     };
     ensure_message_id(&mut message);
+    parse::ensure_date(&mut message);
     parse::escape_message_id_header(&mut message);
     let newsgroups = match message
         .headers
@@ -1310,6 +1312,7 @@ where
             }
         };
         ensure_message_id(&mut article);
+        parse::ensure_date(&mut article);
         parse::escape_message_id_header(&mut article);
         let newsgroups = article
             .headers
@@ -1404,6 +1407,7 @@ where
             }
         };
         ensure_message_id(&mut article);
+        parse::ensure_date(&mut article);
         parse::escape_message_id_header(&mut article);
         let newsgroups = article
             .headers

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -143,3 +143,52 @@ async fn post_without_msgid_generates_one() {
     let id = format!("<{}>", hash.iter().map(|b| format!("{:02x}", b)).collect::<String>());
     assert!(storage.get_article_by_id(&id).await.unwrap().is_some());
 }
+
+#[tokio::test]
+async fn post_without_date_adds_header() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc").await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO USER user\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO PASS pass\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"GROUP misc\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"POST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("340"));
+    line.clear();
+    let article = concat!(
+        "Newsgroups: misc\r\n",
+        "\r\n",
+        "Body\r\n",
+        ".\r\n",
+    );
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("240"));
+    use sha1::{Digest, Sha1};
+    let hash = Sha1::digest(b"Body\r\n");
+    let id = format!("<{}>", hash.iter().map(|b| format!("{:02x}", b)).collect::<String>());
+    let msg = storage.get_article_by_id(&id).await.unwrap().unwrap();
+    let date = msg
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Date"))
+        .map(|(_, v)| v.clone());
+    assert!(date.is_some());
+    chrono::DateTime::parse_from_rfc2822(&date.unwrap()).unwrap();
+}


### PR DESCRIPTION
## Summary
- add `ensure_date` for articles
- insert current date when POST/IHAVE/TAKETHIS receive articles without one
- test that Date header is added during posting

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686720175f208326970a589ea9dcf67b