### PR TITLE
Add admin CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,25 @@ WantedBy=multi-user.target
 Install the file as `/etc/systemd/system/renews.service` and run
 `systemctl enable --now renews` to start the server at boot.
 
+
+## Administration
+
+Use the `admin` subcommand to manage newsgroups and users without starting the
+server. These commands read the same configuration file as the server itself.
+
+```bash
+# configuration is supplied via the environment
+export RENEWS_CONFIG=/opt/renews/config.toml
+
+# add a newsgroup
+renews admin add-group rust.news
+
+# remove a user
+renews admin remove-user alice
+
+# grant admin privileges
+renews admin add-admin alice
+
+# revoke admin privileges
+renews admin remove-admin alice
+```

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -10,3 +10,12 @@ async fn add_and_check_admin() {
     auth.remove_admin("user").await.unwrap();
     assert!(!auth.is_admin("user").await.unwrap());
 }
+
+#[tokio::test]
+async fn add_and_remove_user() {
+    let auth = SqliteAuth::new("sqlite::memory:").await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    assert!(auth.verify_user("user", "pass").await.unwrap());
+    auth.remove_user("user").await.unwrap();
+    assert!(!auth.verify_user("user", "pass").await.unwrap());
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -43,6 +43,10 @@ async fn add_and_list_groups() {
     storage.add_group("g2").await.unwrap();
     let groups = storage.list_groups().await.unwrap();
     assert_eq!(groups, vec!["g1".to_string(), "g2".to_string()]);
+
+    storage.remove_group("g1").await.unwrap();
+    let groups = storage.list_groups().await.unwrap();
+    assert_eq!(groups, vec!["g2".to_string()]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- implement remove_user in auth provider
- add remove_group in storage backend
- add admin subcommand with group and user management
- test user removal and group removal
- fix admin subcommand to accept boolean argument
- document admin usage examples
- document using env var for admin commands
- refine admin CLI commands to `add-admin` and `remove-admin`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68672672944483269a86c7454bb66908