### PR TITLE
Add site_name setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ otherwise `/etc/renews.toml` is assumed. The
 following keys are recognised:
 
 - `port` - TCP port for plain NNTP connections.
+- `site_name` - hostname advertised by the server. Defaults to the `HOSTNAME`
+  environment variable or `localhost` when unset.
 - `db_path` - path to the SQLite database file. Defaults to `/var/spool/renews.db`.
 - `auth_db_path` - optional path to the authentication database. Defaults to `db_path` when unset.
 - `tls_port` - optional port for NNTP over TLS.
@@ -34,6 +36,7 @@ An example configuration is provided in the repository:
 
 ```toml
 port = 1199
+site_name = "example.com"
 db_path = "/var/spool/renews.db"
 auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 port = 1199
+site_name = "example.com"
 db_path = "/var/spool/renews.db"
 auth_db_path = "/var/spool/renews_auth.db"
 tls_port = 563

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,10 @@ fn default_db_path() -> String {
     "/var/spool/renews.db".into()
 }
 
+fn default_site_name() -> String {
+    std::env::var("HOSTNAME").unwrap_or_else(|_| "localhost".into())
+}
+
 fn parse_size(input: &str) -> Option<u64> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -80,6 +84,8 @@ where
 #[derive(Deserialize, Clone)]
 pub struct Config {
     pub port: u16,
+    #[serde(default = "default_site_name")]
+    pub site_name: String,
     #[serde(default = "default_db_path")]
     pub db_path: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary
- introduce `site_name` field in configuration with a default taken from the `HOSTNAME` environment variable
- include the new field in the example config
- document `site_name` in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867b0198ddc8326a3754bf7afc52355