### PR TITLE
Add moderated newsgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ server. These commands read the same configuration file as the server itself.
 export RENEWS_CONFIG=/opt/renews/config.toml
 
 # add a newsgroup
-renews admin add-group rust.news
+renews admin add-group rust.news --moderated
 
 # remove a user
 renews admin remove-user alice

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,11 @@ enum Command {
 #[derive(Subcommand)]
 enum AdminCommand {
     /// Add a newsgroup
-    AddGroup { group: String },
+    AddGroup {
+        group: String,
+        #[arg(long)]
+        moderated: bool,
+    },
     /// Remove a newsgroup
     RemoveGroup { group: String },
     /// Add a user
@@ -76,7 +80,7 @@ async fn run_admin(cmd: AdminCommand, cfg: &Config) -> Result<(), Box<dyn Error 
     let auth_conn = format!("sqlite:{}", auth_path);
     let auth = SqliteAuth::new(&auth_conn).await?;
     match cmd {
-        AdminCommand::AddGroup { group } => storage.add_group(&group).await?,
+        AdminCommand::AddGroup { group, moderated } => storage.add_group(&group, moderated).await?,
         AdminCommand::RemoveGroup { group } => storage.remove_group(&group).await?,
         AdminCommand::AddUser { username, password } => auth.add_user(&username, &password).await?,
         AdminCommand::RemoveUser { username } => auth.remove_user(&username).await?,

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, Utc};
-use renews::storage::{Storage, sqlite::SqliteStorage};
 use renews::parse_message;
+use renews::storage::{Storage, sqlite::SqliteStorage};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
@@ -9,8 +9,12 @@ mod common;
 #[tokio::test]
 async fn head_and_list_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: T\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
@@ -70,8 +74,12 @@ async fn head_and_list_commands() {
 #[tokio::test]
 async fn listgroup_and_navigation_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc", &m1).await.unwrap();
@@ -209,8 +217,12 @@ async fn listgroup_and_navigation_commands() {
 #[tokio::test]
 async fn capabilities_and_misc_commands() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
@@ -292,8 +304,12 @@ async fn capabilities_and_misc_commands() {
 #[tokio::test]
 async fn no_group_returns_412() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
@@ -321,8 +337,12 @@ async fn no_group_returns_412() {
 #[tokio::test]
 async fn responses_include_number_and_id() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
@@ -390,8 +410,12 @@ async fn responses_include_number_and_id() {
 #[tokio::test]
 async fn post_and_dot_stuffing() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
@@ -428,8 +452,12 @@ async fn post_and_dot_stuffing() {
 #[tokio::test]
 async fn body_returns_proper_crlf() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nline1\r\nline2\r\n").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
@@ -466,8 +494,12 @@ async fn body_returns_proper_crlf() {
 #[tokio::test]
 async fn newgroups_accepts_gmt_argument() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;
@@ -504,8 +536,12 @@ async fn newgroups_accepts_gmt_argument() {
 #[tokio::test]
 async fn newnews_accepts_gmt_argument() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
 
@@ -542,8 +578,12 @@ async fn newnews_accepts_gmt_argument() {
 #[tokio::test]
 async fn post_without_selecting_group() {
     let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    let auth = Arc::new(renews::auth::sqlite::SqliteAuth::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+    storage.add_group("misc", false).await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut write_half) = common::connect(addr).await;

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -13,7 +13,7 @@ async fn ihave_rejects_large_article() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap();
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -38,7 +38,7 @@ async fn ihave_rejects_large_article_with_suffix() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap();
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;

--- a/tests/moderated.rs
+++ b/tests/moderated.rs
@@ -1,0 +1,103 @@
+use renews::auth::{AuthProvider, sqlite::SqliteAuth};
+use renews::storage::{Storage, sqlite::SqliteStorage};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+mod common;
+
+#[tokio::test]
+async fn post_requires_approval_for_moderated_group() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("mod.test", true).await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO USER user\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO PASS pass\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"GROUP mod.test\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"POST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("340"));
+    line.clear();
+    let article = concat!(
+        "Message-ID: <p@test>\r\n",
+        "Newsgroups: mod.test\r\n",
+        "From: user@example.com\r\n",
+        "Subject: t\r\n",
+        "\r\n",
+        "Body\r\n",
+        ".\r\n",
+    );
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("441"));
+    assert!(
+        storage
+            .get_article_by_id("<p@test>")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn post_with_approval_succeeds() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("mod.test", true).await.unwrap();
+    auth.add_user("user", "pass").await.unwrap();
+    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO USER user\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"AUTHINFO PASS pass\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"MODE READER\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"GROUP mod.test\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+    writer.write_all(b"POST\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("340"));
+    line.clear();
+    let article = concat!(
+        "Message-ID: <pa@test>\r\n",
+        "Newsgroups: mod.test\r\n",
+        "From: user@example.com\r\n",
+        "Subject: t\r\n",
+        "Approved: yes\r\n",
+        "\r\n",
+        "Body\r\n",
+        ".\r\n",
+    );
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("240"));
+    assert!(
+        storage
+            .get_article_by_id("<pa@test>")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}

--- a/tests/retention.rs
+++ b/tests/retention.rs
@@ -12,7 +12,7 @@ use tokio::time::sleep;
 async fn cleanup_removes_expired() {
     let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=0").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
-    storage.add_group("misc").await.unwrap();
+    storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
     storage.store_article("misc", &msg).await.unwrap();
     sleep(StdDuration::from_secs(1)).await;

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -224,7 +224,7 @@ async fn group_select_returns_211() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -243,7 +243,7 @@ async fn article_success_by_number() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -271,7 +271,7 @@ async fn article_success_by_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -296,7 +296,7 @@ async fn article_id_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -333,7 +333,7 @@ async fn head_success_by_number() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -361,7 +361,7 @@ async fn head_success_by_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -386,7 +386,7 @@ async fn head_number_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -410,7 +410,7 @@ async fn head_id_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -429,7 +429,7 @@ async fn head_no_current_article_selected() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -451,7 +451,7 @@ async fn body_success_by_number() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -479,7 +479,7 @@ async fn body_success_by_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -504,7 +504,7 @@ async fn body_number_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -528,7 +528,7 @@ async fn body_id_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -565,7 +565,7 @@ async fn stat_success_by_number() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -589,7 +589,7 @@ async fn stat_success_by_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -610,7 +610,7 @@ async fn stat_number_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -634,7 +634,7 @@ async fn stat_id_not_found() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -671,7 +671,7 @@ async fn listgroup_returns_numbers() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -721,8 +721,8 @@ async fn list_newsgroups_returns_groups() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
-    storage.add_group("alt.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
+    storage.add_group("alt.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -754,7 +754,7 @@ async fn list_all_keywords() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -841,7 +841,7 @@ async fn newnews_lists_recent_articles() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -876,7 +876,7 @@ async fn newnews_no_matches_returns_empty() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -915,7 +915,7 @@ async fn hdr_subject_by_message_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -942,7 +942,7 @@ async fn hdr_subject_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: A\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: B\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
@@ -979,7 +979,7 @@ async fn hdr_all_headers_message_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) =
         parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody")
             .unwrap();
@@ -1015,7 +1015,7 @@ async fn xpat_subject_message_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
     let (addr, _h) = common::setup_server(storage, auth.clone()).await;
@@ -1045,7 +1045,7 @@ async fn xpat_subject_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: apple\r\n\r\nBody").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: banana\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
@@ -1082,7 +1082,7 @@ async fn over_message_id() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
     storage.store_article("misc.test", &msg).await.unwrap();
@@ -1114,7 +1114,7 @@ async fn over_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) =
         parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
     let (_, m2) =
@@ -1153,7 +1153,7 @@ async fn head_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
@@ -1189,7 +1189,7 @@ async fn body_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
@@ -1225,7 +1225,7 @@ async fn article_range() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
     let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
     storage.store_article("misc.test", &m1).await.unwrap();
@@ -1261,7 +1261,7 @@ async fn ihave_example() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
 
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -1309,7 +1309,7 @@ async fn takethis_example() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (_, exist) = parse_message(
         "Message-ID: <i.am.an.article.you.have@example.com>\r\nNewsgroups: misc.test\r\n\r\nBody",
     )
@@ -1366,7 +1366,7 @@ async fn mode_stream_check_and_takethis() {
             .await
             .unwrap(),
     );
-    storage.add_group("misc.test").await.unwrap();
+    storage.add_group("misc.test", false).await.unwrap();
     let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -39,8 +39,8 @@ async fn numbering_is_per_group() {
 async fn add_and_list_groups() {
     let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
     assert!(storage.list_groups().await.unwrap().is_empty());
-    storage.add_group("g1").await.unwrap();
-    storage.add_group("g2").await.unwrap();
+    storage.add_group("g1", false).await.unwrap();
+    storage.add_group("g2", false).await.unwrap();
     let groups = storage.list_groups().await.unwrap();
     assert_eq!(groups, vec!["g1".to_string(), "g2".to_string()]);
 
@@ -56,8 +56,8 @@ async fn purge_old_articles() {
     use tokio::time::sleep;
 
     let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
-    storage.add_group("g1").await.unwrap();
-    storage.add_group("g2").await.unwrap();
+    storage.add_group("g1", false).await.unwrap();
+    storage.add_group("g2", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
     storage.store_article("g1", &msg).await.unwrap();
     storage.store_article("g2", &msg).await.unwrap();


### PR DESCRIPTION
## Summary
- support marking groups as moderated
- reject posts to moderated groups without Approved header
- allow creating moderated groups via admin CLI and control messages
- document moderated groups
- add tests for moderated behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867af687fac83268c2b59c93c1be573