### PR TITLE
Support cancel-lock and cancel-key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 sha1 = "0.10"
 pgp = "0.16"
 rand = "0.8"
+base64 = "0.21"
+sha2 = "0.10"
 
 [dev-dependencies]
 rcgen = "0.14"

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,5 +1,7 @@
 use crate::{Message, auth::DynAuth, storage::DynStorage};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use pgp::composed::{Deserializable, SignedPublicKey, StandaloneSignature};
+use sha2::{Digest, Sha256, Sha512};
 use std::error::Error;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -29,6 +31,40 @@ fn parse_command(val: &str) -> Option<ControlCommand> {
         "rmgroup" => parts.next().map(|g| ControlCommand::RmGroup(g.to_string())),
         _ => None,
     }
+}
+
+fn parse_elements(val: &str) -> Vec<(String, String)> {
+    val.split_whitespace()
+        .filter_map(|p| {
+            let p = p.trim_matches(',');
+            p.split_once(':')
+                .map(|(s, v)| (s.to_ascii_lowercase(), v.to_string()))
+        })
+        .collect()
+}
+
+fn hash_key(scheme: &str, key: &str) -> Option<String> {
+    let bytes = key.as_bytes();
+    let digest = match scheme {
+        "sha256" => Sha256::digest(bytes).to_vec(),
+        "sha512" => Sha512::digest(bytes).to_vec(),
+        "sha1" => sha1::Sha1::digest(bytes).to_vec(),
+        _ => return None,
+    };
+    Some(STANDARD.encode(digest))
+}
+
+fn verify_cancel(keys: &[(String, String)], locks: &[(String, String)]) -> bool {
+    for (scheme, key) in keys {
+        if let Some(hash) = hash_key(scheme, key) {
+            for (ls, lv) in locks {
+                if scheme.eq_ignore_ascii_case(ls) && *lv == hash {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Build the canonical text that was signed according to the pgpcontrol format.
@@ -95,6 +131,34 @@ pub async fn handle_control(
         Some((_, v)) => v.clone(),
         None => return Ok(false),
     };
+    let cmd = parse_command(&control_val).ok_or("unknown control")?;
+
+    if let ControlCommand::Cancel(ref id) = cmd {
+        // try Cancel-Key authentication first
+        if let Some((_, key_val)) = msg
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("Cancel-Key"))
+        {
+            if let Some(orig) = storage.get_article_by_id(id).await? {
+                if let Some((_, lock_val)) = orig
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("Cancel-Lock"))
+                {
+                    let keys = parse_elements(key_val);
+                    let locks = parse_elements(lock_val);
+                    if verify_cancel(&keys, &locks) {
+                        storage.delete_article_by_id(id).await?;
+                    }
+                    return Ok(true);
+                }
+            }
+            return Ok(true);
+        }
+    }
+
+    // fall back to admin-signed control message
     let from = msg
         .headers
         .iter()
@@ -115,7 +179,6 @@ pub async fn handle_control(
     let signed = words.next().ok_or("bad signature")?;
     let sig_rest = words.collect::<Vec<_>>().join("\n");
     verify_pgp(msg, auth, from, version, signed, &sig_rest).await?;
-    let cmd = parse_command(&control_val).ok_or("unknown control")?;
     match cmd {
         ControlCommand::Cancel(id) => {
             storage.delete_article_by_id(&id).await?;

--- a/tests/cancel_lock.rs
+++ b/tests/cancel_lock.rs
@@ -1,0 +1,52 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use renews::auth::{AuthProvider, sqlite::SqliteAuth};
+use renews::parse_message;
+use renews::storage::{Storage, sqlite::SqliteStorage};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+mod common;
+
+#[tokio::test]
+async fn cancel_key_allows_cancel() {
+    let storage = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let auth = Arc::new(SqliteAuth::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc.test", false).await.unwrap();
+
+    let key = "secret";
+    let key_b64 = STANDARD.encode(key);
+    let lock_hash = Sha256::digest(key_b64.as_bytes());
+    let lock_b64 = STANDARD.encode(lock_hash);
+    let orig = format!(
+        "Message-ID: <a@test>\r\nNewsgroups: misc.test\r\nCancel-Lock: sha256:{}\r\n\r\nBody",
+        lock_b64
+    );
+    let (_, msg) = parse_message(&orig).unwrap();
+    storage.store_article("misc.test", &msg).await.unwrap();
+
+    let (addr, _h) = common::setup_server(storage.clone(), auth.clone()).await;
+    let (mut reader, mut writer) = common::connect(addr).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    writer.write_all(b"IHAVE <c@test>\r\n").await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    line.clear();
+
+    let cancel = format!(
+        "Message-ID: <c@test>\r\nNewsgroups: misc.test\r\nControl: cancel <a@test>\r\nCancel-Key: sha256:{}\r\n\r\n.\r\n",
+        key_b64
+    );
+    writer.write_all(cancel.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("235"));
+    assert!(
+        storage
+            .get_article_by_id("<a@test>")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}


### PR DESCRIPTION
## Summary
- support `Cancel-Key`/`Cancel-Lock` authentication for cancel control articles
- implement SHA-based hash checking for cancel locks
- test cancel-key based article cancellation

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867f3ac2c548326a7c27543cf02dd29