### PR TITLE
Improve retention logic with Expires header

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -145,10 +145,14 @@ impl Config {
     pub fn retention_for_group(&self, group: &str) -> Option<Duration> {
         if let Some(rule) = self.rule_for_group(group) {
             if let Some(days) = rule.retention_days {
-                return Some(Duration::days(days));
+                if days > 0 {
+                    return Some(Duration::days(days));
+                } else {
+                    return None;
+                }
             }
         }
-        self.default_retention_days.map(Duration::days)
+        self.default_retention_days.and_then(|d| if d > 0 { Some(Duration::days(d)) } else { None })
     }
 
     pub fn max_size_for_group(&self, group: &str) -> Option<u64> {

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::storage::Storage;
-use chrono::Utc;
+use crate::Message;
+use chrono::{DateTime, Utc};
 use std::error::Error;
 
 pub async fn cleanup_expired_articles(
@@ -8,12 +9,36 @@ pub async fn cleanup_expired_articles(
     cfg: &Config,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let groups = storage.list_groups().await?;
+    let now = Utc::now();
     for g in groups {
-        if let Some(ret) = cfg.retention_for_group(&g) {
-            let cutoff = Utc::now() - ret;
-            storage.purge_group_before(&g, cutoff).await?;
+        let retention = cfg.retention_for_group(&g);
+        if let Some(ret) = retention {
+            if ret.num_seconds() > 0 {
+                let cutoff = now - ret;
+                storage.purge_group_before(&g, cutoff).await?;
+            }
+        }
+
+        // Expire articles with an Expires header in the past
+        let ids = storage.list_article_ids(&g).await?;
+        for id in ids {
+            if let Some(article) = storage.get_article_by_id(&id).await? {
+                if let Some(exp) = expires_time(&article) {
+                    if exp <= now {
+                        storage.delete_article_by_id(&id).await?;
+                    }
+                }
+            }
         }
     }
     storage.purge_orphan_messages().await?;
     Ok(())
+}
+
+fn expires_time(msg: &Message) -> Option<DateTime<Utc>> {
+    msg.headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Expires"))
+        .and_then(|(_, v)| chrono::DateTime::parse_from_rfc2822(v).or_else(|_| chrono::DateTime::parse_from_rfc3339(v)).ok())
+        .map(|dt| dt.with_timezone(&Utc))
 }

--- a/tests/retention.rs
+++ b/tests/retention.rs
@@ -9,7 +9,7 @@ use std::time::Duration as StdDuration;
 use tokio::time::sleep;
 
 #[tokio::test]
-async fn cleanup_removes_expired() {
+async fn cleanup_retention_zero_keeps_articles() {
     let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=0").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
@@ -20,6 +20,26 @@ async fn cleanup_removes_expired() {
     assert!(
         storage
             .get_article_by_id("<1@test>")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn cleanup_expires_header() {
+    use chrono::Duration as ChronoDuration;
+    let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=10").unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage.add_group("misc", false).await.unwrap();
+    let past = (chrono::Utc::now() - ChronoDuration::days(1)).to_rfc2822();
+    let text = format!("Message-ID: <2@test>\r\nExpires: {}\r\n\r\nB", past);
+    let (_, msg) = parse_message(&text).unwrap();
+    storage.store_article("misc", &msg).await.unwrap();
+    cleanup_expired_articles(&*storage, &cfg).await.unwrap();
+    assert!(
+        storage
+            .get_article_by_id("<2@test>")
             .await
             .unwrap()
             .is_none()


### PR DESCRIPTION
## Summary
- treat zero retention as infinite
- allow Expires header to force early deletion
- update retention tests accordingly

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686825cd03ac8326bf8c95b265fc353f