### PR TITLE
Support runtime TLS reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/renews --config /opt/renews/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/renews
 Restart=on-failure
 User=renews
@@ -82,6 +83,10 @@ WantedBy=multi-user.target
 
 Install the file as `/etc/systemd/system/renews.service` and run
 `systemctl enable --now renews` to start the server at boot.
+
+Sending `SIGHUP` to the process (for example with `systemctl reload`) reloads
+the configuration. Retention, group, and TLS settings are updated at runtime;
+the listening ports and database paths remain unchanged.
 
 
 ## Administration

--- a/examples/systemd/renews.service
+++ b/examples/systemd/renews.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/renews --config /opt/renews/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/renews
 Restart=on-failure
 User=renews

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,4 +160,14 @@ impl Config {
             .and_then(|r| r.max_article_bytes)
             .or(self.default_max_article_bytes)
     }
+
+    /// Update runtime-adjustable values from a new configuration.
+    /// Only retention, group, and TLS settings are changed.
+    pub fn update_runtime(&mut self, other: Config) {
+        self.default_retention_days = other.default_retention_days;
+        self.default_max_article_bytes = other.default_max_article_bytes;
+        self.group_settings = other.group_settings;
+        self.tls_cert = other.tls_cert;
+        self.tls_key = other.tls_key;
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,14 @@
-use renews::handle_client;
-use renews::storage::Storage;
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use renews::auth::AuthProvider;
 use renews::config::Config;
+use renews::handle_client;
+use renews::storage::Storage;
 use std::sync::Arc;
 use tokio::io::BufReader;
-use tokio::net::{TcpListener, TcpStream};
-use tokio_rustls::{TlsAcceptor, TlsConnector, rustls};
 use tokio::io::{self, ReadHalf, WriteHalf};
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+use tokio_rustls::{TlsAcceptor, TlsConnector, rustls};
 
 pub async fn setup_server(
     storage: Arc<dyn Storage>,
@@ -17,10 +18,12 @@ pub async fn setup_server(
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
     let auth_clone = auth.clone();
-    let cfg: Config = toml::from_str("port=1199").unwrap();
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("port=1199").unwrap()));
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone, auth_clone, cfg, false).await.unwrap();
+        handle_client(sock, store_clone, auth_clone, cfg, false)
+            .await
+            .unwrap();
     });
     (addr, handle)
 }
@@ -28,7 +31,7 @@ pub async fn setup_server(
 pub async fn setup_server_with_cfg(
     storage: Arc<dyn Storage>,
     auth: Arc<dyn AuthProvider>,
-    cfg: Config,
+    cfg: Arc<RwLock<Config>>,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -36,7 +39,9 @@ pub async fn setup_server_with_cfg(
     let auth_clone = auth.clone();
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
-        handle_client(sock, store_clone, auth_clone, cfg, false).await.unwrap();
+        handle_client(sock, store_clone, auth_clone, cfg, false)
+            .await
+            .unwrap();
     });
     (addr, handle)
 }
@@ -67,14 +72,17 @@ pub async fn setup_tls_server(
     let tls_config = rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_no_client_auth()
-        .with_single_cert(vec![rustls::Certificate(cert_der.clone())], rustls::PrivateKey(key))
+        .with_single_cert(
+            vec![rustls::Certificate(cert_der.clone())],
+            rustls::PrivateKey(key),
+        )
         .unwrap();
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
     let auth_clone = auth.clone();
-    let cfg: Config = toml::from_str("port=1199").unwrap();
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("port=1199").unwrap()));
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
         let stream = acceptor.accept(sock).await.unwrap();

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -21,3 +21,45 @@ max_article_bytes = "20K"
     assert_eq!(cfg.max_size_for_group("foo.test"), Some(1024));
     assert_eq!(cfg.max_size_for_group("foo.bar"), Some(20480));
 }
+
+#[test]
+fn runtime_update_preserves_immutable_fields() {
+    let initial = r#"port = 1199
+db_path = "/tmp/db1"
+auth_db_path = "/tmp/auth1"
+tls_port = 563
+tls_cert = "old.pem"
+tls_key = "old.key"
+default_retention_days = 10
+default_max_article_bytes = 100
+[[group_settings]]
+group = "misc.news"
+retention_days = 5
+"#;
+    let mut cfg: Config = toml::from_str(initial).unwrap();
+
+    let updated = r#"port = 42
+db_path = "/tmp/db2"
+auth_db_path = "/tmp/auth2"
+tls_port = 9999
+tls_cert = "new.pem"
+tls_key = "new.key"
+default_retention_days = 1
+default_max_article_bytes = 200
+[[group_settings]]
+group = "misc.news"
+retention_days = 1
+"#;
+    let new_cfg: Config = toml::from_str(updated).unwrap();
+    cfg.update_runtime(new_cfg);
+
+    assert_eq!(cfg.port, 1199);
+    assert_eq!(cfg.db_path, "/tmp/db1");
+    assert_eq!(cfg.auth_db_path.as_deref(), Some("/tmp/auth1"));
+    assert_eq!(cfg.tls_port, Some(563));
+    assert_eq!(cfg.tls_cert.as_deref(), Some("new.pem"));
+    assert_eq!(cfg.tls_key.as_deref(), Some("new.key"));
+    assert_eq!(cfg.default_retention_days, Some(1));
+    assert_eq!(cfg.default_max_article_bytes, Some(200));
+    assert_eq!(cfg.group_settings[0].retention_days, Some(1));
+}

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -2,6 +2,7 @@ use renews::config::Config;
 use renews::storage::{Storage, sqlite::SqliteStorage};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::sync::RwLock;
 
 mod common;
 
@@ -14,7 +15,9 @@ async fn ihave_rejects_large_article() {
             .unwrap(),
     );
     storage.add_group("misc.test", false).await.unwrap();
-    let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap();
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
+        toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap(),
+    ));
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();
@@ -39,7 +42,9 @@ async fn ihave_rejects_large_article_with_suffix() {
             .unwrap(),
     );
     storage.add_group("misc.test", false).await.unwrap();
-    let cfg: Config = toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap();
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
+        toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap(),
+    ));
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
     let mut line = String::new();


### PR DESCRIPTION
## Summary
- reload TLS settings when receiving SIGHUP
- expand runtime update to include TLS cert/key
- update systemd unit example with `ExecReload`
- document TLS reload behaviour
- extend configuration reload test

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68682c37cd048326a691a3e67b4c0aed