### PR TITLE
Add peer article transfer using IHAVE or TAKETHIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ following keys are recognised:
 - `port` - TCP port for plain NNTP connections.
 - `site_name` - hostname advertised by the server. Defaults to the `HOSTNAME`
   environment variable or `localhost` when unset.
-- `db_path` - path to the SQLite database file. Defaults to `/var/spool/renews.db`.
-- `auth_db_path` - optional path to the authentication database. Defaults to `db_path` when unset.
+- `db_path` - path to the SQLite database file. Defaults to `/var/renews/news.db`.
+- `auth_db_path` - optional path to the authentication database. Defaults to `/var/renews/auth.db` when unset.
+- `peer_db_path` - path to the peer state database. Defaults to `/var/renews/peers.db`.
+- `peer_sync_secs` - default seconds between synchronizing with peers.
+- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged.
 - `tls_port` - optional port for NNTP over TLS.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
@@ -37,8 +40,10 @@ An example configuration is provided in the repository:
 ```toml
 port = 1199
 site_name = "example.com"
-db_path = "/var/spool/renews.db"
-auth_db_path = "/var/spool/renews_auth.db"
+db_path = "/var/renews/news.db"
+auth_db_path = "/var/renews/auth.db"
+peer_db_path = "/var/renews/peers.db"
+peer_sync_secs = 3600
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
@@ -53,6 +58,11 @@ retention_days = 7
 group = "misc.news"
 retention_days = 60
 max_article_bytes = "2M"
+
+[[peers]]
+sitename = "peer.example.com"
+patterns = ["*"]
+sync_interval_secs = 3600
 ```
 
 `tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,9 @@
 port = 1199
 site_name = "example.com"
-db_path = "/var/spool/renews.db"
-auth_db_path = "/var/spool/renews_auth.db"
+db_path = "/var/renews/news.db"
+auth_db_path = "/var/renews/auth.db"
+peer_db_path = "/var/renews/peers.db"
+peer_sync_secs = 3600
 tls_port = 563
 tls_cert = "cert.pem"
 tls_key = "key.pem"
@@ -17,3 +19,8 @@ retention_days = 7
 group = "misc.news"
 retention_days = 60
 max_article_bytes = "2M"
+
+[[peers]]
+sitename = "peer.example.com"
+patterns = ["*"]
+sync_interval_secs = 3600

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use parse::{
 pub mod auth;
 pub mod config;
 pub mod control;
+pub mod peers;
 pub mod retention;
 pub mod storage;
 pub mod wildmat;
@@ -108,7 +109,7 @@ const RESP_100_HELP_FOLLOWS: &str = "100 help text follows\r\n";
 const RESP_203_STREAMING_PERMITTED: &str = "203 Streaming permitted\r\n";
 const DOT: &str = ".";
 
-fn extract_message_id(msg: &Message) -> Option<&str> {
+pub fn extract_message_id(msg: &Message) -> Option<&str> {
     msg.headers.iter().find_map(|(k, v)| {
         if k.eq_ignore_ascii_case("Message-ID") {
             Some(v.as_str())
@@ -118,7 +119,7 @@ fn extract_message_id(msg: &Message) -> Option<&str> {
     })
 }
 
-async fn send_body<W: AsyncWrite + Unpin>(
+pub async fn send_body<W: AsyncWrite + Unpin>(
     writer: &mut W,
     body: &str,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -141,7 +142,7 @@ async fn send_body<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-async fn send_headers<W: AsyncWrite + Unpin>(
+pub async fn send_headers<W: AsyncWrite + Unpin>(
     writer: &mut W,
     article: &Message,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -153,7 +154,7 @@ async fn send_headers<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-async fn write_simple<W: AsyncWrite + Unpin>(
+pub async fn write_simple<W: AsyncWrite + Unpin>(
     writer: &mut W,
     msg: &str,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -1,0 +1,214 @@
+use chrono::{DateTime, Utc};
+use sqlx::{Row, SqlitePool, sqlite::SqlitePoolOptions};
+use std::error::Error;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+use crate::storage::DynStorage;
+use crate::wildmat::wildmat;
+use crate::{Message, extract_message_id, send_body, send_headers, write_simple};
+
+#[derive(Clone)]
+pub struct PeerDb {
+    pool: SqlitePool,
+}
+
+impl PeerDb {
+    pub async fn new(path: &str) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(path)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS peers (\n                sitename TEXT PRIMARY KEY,\n                last_sync INTEGER\n            )",
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { pool })
+    }
+
+    pub async fn list_peers(&self) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+        let rows = sqlx::query("SELECT sitename FROM peers")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| r.try_get("sitename").unwrap())
+            .collect())
+    }
+
+    pub async fn sync_config(&self, names: &[String]) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let existing = self.list_peers().await?;
+        for n in names {
+            if !existing.iter().any(|e| e == n) {
+                sqlx::query("INSERT INTO peers (sitename, last_sync) VALUES (?, 0)")
+                    .bind(n)
+                    .execute(&self.pool)
+                    .await?;
+            }
+        }
+        for e in existing {
+            if !names.iter().any(|n| n == &e) {
+                sqlx::query("DELETE FROM peers WHERE sitename = ?")
+                    .bind(e)
+                    .execute(&self.pool)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn update_last_sync(
+        &self,
+        name: &str,
+        when: DateTime<Utc>,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        sqlx::query("UPDATE peers SET last_sync = ? WHERE sitename = ?")
+            .bind(when.timestamp())
+            .bind(name)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn get_last_sync(
+        &self,
+        name: &str,
+    ) -> Result<Option<DateTime<Utc>>, Box<dyn Error + Send + Sync>> {
+        if let Some(row) = sqlx::query("SELECT last_sync FROM peers WHERE sitename = ?")
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?
+        {
+            let ts: i64 = row.try_get("last_sync")?;
+            if ts == 0 {
+                return Ok(None);
+            }
+            Ok(Some(DateTime::<Utc>::from_naive_utc_and_offset(
+                chrono::NaiveDateTime::from_timestamp(ts, 0),
+                Utc,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PeerConfig {
+    pub sitename: String,
+    pub patterns: Vec<String>,
+    pub sync_interval_secs: Option<u64>,
+}
+
+impl From<&crate::config::PeerRule> for PeerConfig {
+    fn from(r: &crate::config::PeerRule) -> Self {
+        Self {
+            sitename: r.sitename.clone(),
+            patterns: r.patterns.clone(),
+            sync_interval_secs: r.sync_interval_secs,
+        }
+    }
+}
+
+pub async fn peer_task(
+    peer: PeerConfig,
+    default_interval: u64,
+    db: PeerDb,
+    storage: DynStorage,
+    site_name: String,
+) {
+    let interval = peer.sync_interval_secs.unwrap_or(default_interval);
+    let delay = tokio::time::Duration::from_secs(interval.max(1));
+    let use_takethis = peer.sync_interval_secs == Some(0);
+    loop {
+        if let Err(e) = sync_peer_once(&peer, &db, &storage, &site_name, use_takethis).await {
+            tracing::error!("peer sync error: {e}");
+        }
+        let _ = db.update_last_sync(&peer.sitename, Utc::now()).await;
+        tokio::time::sleep(delay).await;
+    }
+}
+
+async fn send_article(
+    host: &str,
+    article: &Message,
+    use_takethis: bool,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let msg_id = extract_message_id(article).ok_or("missing Message-ID")?;
+    let mut stream = TcpStream::connect(host).await?;
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?; // greeting
+    if use_takethis {
+        write_simple(&mut write_half, "MODE STREAM\r\n").await?;
+        line.clear();
+        reader.read_line(&mut line).await?; // ignore
+        write_simple(&mut write_half, &format!("TAKETHIS {}\r\n", msg_id)).await?;
+    } else {
+        write_simple(&mut write_half, &format!("IHAVE {}\r\n", msg_id)).await?;
+        line.clear();
+        reader.read_line(&mut line).await?;
+        if !line.starts_with("335") {
+            return Ok(());
+        }
+    }
+    send_headers(&mut write_half, article).await?;
+    write_simple(&mut write_half, "\r\n").await?;
+    send_body(&mut write_half, &article.body).await?;
+    write_simple(&mut write_half, ".\r\n").await?;
+    line.clear();
+    reader.read_line(&mut line).await?;
+    let _ = write_half.shutdown().await;
+    Ok(())
+}
+
+async fn sync_peer_once(
+    peer: &PeerConfig,
+    db: &PeerDb,
+    storage: &DynStorage,
+    site_name: &str,
+    use_takethis: bool,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let last = db.get_last_sync(&peer.sitename).await?;
+    let groups = storage.list_groups().await?;
+    for group in groups {
+        if !peer.patterns.iter().any(|p| wildmat(p, &group)) {
+            continue;
+        }
+        let ids = if let Some(ts) = last {
+            storage.list_article_ids_since(&group, ts).await?
+        } else {
+            storage.list_article_ids(&group).await?
+        };
+        for id in ids {
+            if let Some(orig) = storage.get_article_by_id(&id).await? {
+                let mut article = Message {
+                    headers: orig.headers.clone(),
+                    body: orig.body.clone(),
+                };
+                let mut has_path = false;
+                let mut skip = false;
+                for (k, v) in article.headers.iter_mut() {
+                    if k.eq_ignore_ascii_case("Path") {
+                        if v.split('!').any(|s| s.trim() == peer.sitename) {
+                            skip = true;
+                            break;
+                        }
+                        *v = format!("{}!{}", site_name, v);
+                        has_path = true;
+                    }
+                }
+                if skip {
+                    continue;
+                }
+                if !has_path {
+                    article.headers.push(("Path".into(), site_name.to_string()));
+                }
+                let _ = send_article(&peer.sitename, &article, use_takethis).await;
+            }
+        }
+    }
+    Ok(())
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -27,6 +27,8 @@ fn runtime_update_preserves_immutable_fields() {
     let initial = r#"port = 1199
 db_path = "/tmp/db1"
 auth_db_path = "/tmp/auth1"
+peer_db_path = "/tmp/peer1"
+peer_sync_secs = 1800
 tls_port = 563
 tls_cert = "old.pem"
 tls_key = "old.key"
@@ -41,6 +43,8 @@ retention_days = 5
     let updated = r#"port = 42
 db_path = "/tmp/db2"
 auth_db_path = "/tmp/auth2"
+peer_db_path = "/tmp/peer2"
+peer_sync_secs = 3600
 tls_port = 9999
 tls_cert = "new.pem"
 tls_key = "new.key"
@@ -56,10 +60,21 @@ retention_days = 1
     assert_eq!(cfg.port, 1199);
     assert_eq!(cfg.db_path, "/tmp/db1");
     assert_eq!(cfg.auth_db_path.as_deref(), Some("/tmp/auth1"));
+    assert_eq!(cfg.peer_db_path, "/tmp/peer1");
+    assert_eq!(cfg.peer_sync_secs, 3600);
     assert_eq!(cfg.tls_port, Some(563));
     assert_eq!(cfg.tls_cert.as_deref(), Some("new.pem"));
     assert_eq!(cfg.tls_key.as_deref(), Some("new.key"));
     assert_eq!(cfg.default_retention_days, Some(1));
     assert_eq!(cfg.default_max_article_bytes, Some(200));
     assert_eq!(cfg.group_settings[0].retention_days, Some(1));
+}
+
+#[test]
+fn default_paths() {
+    let cfg: Config = toml::from_str("port=1199").unwrap();
+    assert_eq!(cfg.db_path, "/var/renews/news.db");
+    assert_eq!(cfg.auth_db_path.as_deref(), Some("/var/renews/auth.db"));
+    assert_eq!(cfg.peer_db_path, "/var/renews/peers.db");
+    assert_eq!(cfg.peer_sync_secs, 3600);
 }

--- a/tests/peers.rs
+++ b/tests/peers.rs
@@ -1,0 +1,118 @@
+use renews::peers::{PeerConfig, PeerDb, peer_task};
+use renews::storage::Storage;
+use renews::storage::sqlite::SqliteStorage;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::sync::RwLock;
+
+use test_utils as common;
+
+#[tokio::test]
+async fn add_and_remove_peers() {
+    let db = PeerDb::new("sqlite::memory:").await.unwrap();
+    db.sync_config(&["a".into(), "b".into()]).await.unwrap();
+    let mut list = db.list_peers().await.unwrap();
+    list.sort();
+    assert_eq!(list, vec!["a", "b"]);
+    db.sync_config(&["b".into()]).await.unwrap();
+    let list = db.list_peers().await.unwrap();
+    assert_eq!(list, vec!["b"]);
+}
+
+#[tokio::test]
+async fn peer_task_updates_last_sync() {
+    let db = PeerDb::new("sqlite::memory:").await.unwrap();
+    db.sync_config(&["127.0.0.1:9".into()]).await.unwrap();
+    let storage = SqliteStorage::new("sqlite::memory:").await.unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(storage);
+    let peer = PeerConfig {
+        sitename: "127.0.0.1:9".into(),
+        patterns: vec![],
+        sync_interval_secs: Some(1),
+    };
+    let db_clone = db.clone();
+    let storage_clone = storage.clone();
+    tokio::spawn(async move {
+        peer_task(peer, 1, db_clone, storage_clone, "local".into()).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+    let last = db.get_last_sync("127.0.0.1:9").await.unwrap();
+    assert!(last.is_some());
+}
+
+async fn peer_transfer_helper(interval: u64) {
+    let storage_a: Arc<dyn Storage> =
+        Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    let storage_b: Arc<dyn Storage> =
+        Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
+    storage_a.add_group("misc.test", false).await.unwrap();
+    storage_b.add_group("misc.test", false).await.unwrap();
+    let auth = Arc::new(
+        renews::auth::sqlite::SqliteAuth::new("sqlite::memory:")
+            .await
+            .unwrap(),
+    );
+
+    let cfg_a: Arc<RwLock<renews::config::Config>> = Arc::new(RwLock::new(
+        toml::from_str("port=1199\nsite_name='A'").unwrap(),
+    ));
+    let cfg_b: Arc<RwLock<renews::config::Config>> = Arc::new(RwLock::new(
+        toml::from_str("port=1199\nsite_name='B'").unwrap(),
+    ));
+
+    let (addr_b, handle_b) =
+        common::setup_server_with_cfg(storage_b.clone(), auth.clone(), cfg_b).await;
+    let (addr_a, handle_a) =
+        common::setup_server_with_cfg(storage_a.clone(), auth.clone(), cfg_a).await;
+
+    let (mut reader, mut writer) = common::connect(addr_a).await;
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    writer.write_all(b"IHAVE <1@test>\r\n").await.unwrap();
+    line.clear();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("335"));
+    let article = "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nFrom: a@test\r\nSubject: hello\r\n\r\nbody\r\n.\r\n";
+    line.clear();
+    writer.write_all(article.as_bytes()).await.unwrap();
+    reader.read_line(&mut line).await.unwrap();
+    assert!(line.starts_with("235"));
+    let _ = writer.shutdown().await;
+    handle_a.await.unwrap();
+
+    let db = PeerDb::new("sqlite::memory:").await.unwrap();
+    let peer_name = format!("{}", addr_b);
+    db.sync_config(&[peer_name.clone()]).await.unwrap();
+    let peer = PeerConfig {
+        sitename: peer_name.clone(),
+        patterns: vec!["*".into()],
+        sync_interval_secs: Some(interval),
+    };
+    let db_clone = db.clone();
+    let storage_clone = storage_a.clone();
+    let peer_handle = tokio::spawn(async move {
+        peer_task(peer, 1, db_clone, storage_clone, "A".into()).await;
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    peer_handle.abort();
+    handle_b.await.unwrap();
+
+    assert!(
+        storage_b
+            .get_article_by_id("<1@test>")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn peer_transfer_interval_zero() {
+    peer_transfer_helper(0).await;
+}
+
+#[tokio::test]
+async fn peer_transfer_interval_one() {
+    peer_transfer_helper(1).await;
+}


### PR DESCRIPTION
## Summary
- export NNTP helper functions publicly
- allow peer sync to connect using provided host address
- add helper to verify article transfer between peers
- test IHAVE and TAKETHIS peer transfers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68687daa70248326b0b6b10d37f7fff8