### PR TITLE
Enable TLS for peer connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +666,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -979,6 +1002,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1078,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -1647,6 +1686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,9 +2087,11 @@ dependencies = [
  "rand",
  "rand_core",
  "rcgen",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1",
  "sha2",
  "sqlx",
@@ -2151,6 +2198,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2287,29 @@ dependencies = [
  "serdect 0.2.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2286,6 +2377,31 @@ checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1"
 toml = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "clock"] }
 tokio-rustls = "0.24"
+rustls-native-certs = "0.6"
 rustls-pemfile = "1"
 clap = { version = "4", features = ["derive", "env"] }
 argon2 = { version = "0.5", features = ["std"] }
@@ -29,3 +30,4 @@ sha2 = "0.10"
 tempfile = "3"
 rcgen = "0.14"
 test_utils = { path = "test_utils" }
+serial_test = "2"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ following keys are recognised:
 An example configuration is provided in the repository:
 
 ```toml
-port = 1199
+port = 119
 site_name = "example.com"
 db_path = "/var/renews/news.db"
 auth_db_path = "/var/renews/auth.db"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-port = 1199
+port = 119
 site_name = "example.com"
 db_path = "/var/renews/news.db"
 auth_db_path = "/var/renews/auth.db"

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,7 +2,7 @@ use renews::config::Config;
 
 #[test]
 fn retention_rules_match() {
-    let toml = r#"port = 1199
+    let toml = r#"port = 119
 default_retention_days = 10
 default_max_article_bytes = "1K"
 [[group_settings]]
@@ -24,7 +24,7 @@ max_article_bytes = "20K"
 
 #[test]
 fn runtime_update_preserves_immutable_fields() {
-    let initial = r#"port = 1199
+    let initial = r#"port = 119
 db_path = "/tmp/db1"
 auth_db_path = "/tmp/auth1"
 peer_db_path = "/tmp/peer1"
@@ -57,7 +57,7 @@ retention_days = 1
     let new_cfg: Config = toml::from_str(updated).unwrap();
     cfg.update_runtime(new_cfg);
 
-    assert_eq!(cfg.port, 1199);
+    assert_eq!(cfg.port, 119);
     assert_eq!(cfg.db_path, "/tmp/db1");
     assert_eq!(cfg.auth_db_path.as_deref(), Some("/tmp/auth1"));
     assert_eq!(cfg.peer_db_path, "/tmp/peer1");
@@ -72,7 +72,7 @@ retention_days = 1
 
 #[test]
 fn default_paths() {
-    let cfg: Config = toml::from_str("port=1199").unwrap();
+    let cfg: Config = toml::from_str("port=119").unwrap();
     assert_eq!(cfg.db_path, "/var/renews/news.db");
     assert_eq!(cfg.auth_db_path.as_deref(), Some("/var/renews/auth.db"));
     assert_eq!(cfg.peer_db_path, "/var/renews/peers.db");

--- a/tests/max_size.rs
+++ b/tests/max_size.rs
@@ -16,7 +16,7 @@ async fn ihave_rejects_large_article() {
     );
     storage.add_group("misc.test", false).await.unwrap();
     let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
-        toml::from_str("port=1199\ndefault_max_article_bytes=10\n").unwrap(),
+        toml::from_str("port=119\ndefault_max_article_bytes=10\n").unwrap(),
     ));
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;
@@ -43,7 +43,7 @@ async fn ihave_rejects_large_article_with_suffix() {
     );
     storage.add_group("misc.test", false).await.unwrap();
     let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
-        toml::from_str("port=1199\ndefault_max_article_bytes=\"1K\"\n").unwrap(),
+        toml::from_str("port=119\ndefault_max_article_bytes=\"1K\"\n").unwrap(),
     ));
     let (addr, _h) = common::setup_server_with_cfg(storage.clone(), auth.clone(), cfg).await;
     let (mut reader, mut writer) = common::connect(addr).await;

--- a/tests/moderated.rs
+++ b/tests/moderated.rs
@@ -99,7 +99,7 @@ async fn post_requires_approval_for_moderated_group() {
     let auth = Arc::new(SqliteAuth::new("sqlite::memory:").await.unwrap());
     storage.add_group("mod.test", true).await.unwrap();
     auth.add_user("user", "pass").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -149,7 +149,7 @@ async fn post_with_approval_succeeds() {
     auth.add_user("user", "pass").await.unwrap();
     auth.update_pgp_key("user", ADMIN_PUB).await.unwrap();
     auth.add_moderator("user", "mod.*").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -196,7 +196,7 @@ async fn cross_post_different_moderators() {
     auth.update_pgp_key("mod2", ADMIN_PUB).await.unwrap();
     auth.add_moderator("mod1", "mod.one").await.unwrap();
     auth.add_moderator("mod2", "mod.two").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();

--- a/tests/retention.rs
+++ b/tests/retention.rs
@@ -10,7 +10,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn cleanup_retention_zero_keeps_articles() {
-    let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=0").unwrap();
+    let cfg: Config = toml::from_str("port=119\ndefault_retention_days=0").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
@@ -29,7 +29,7 @@ async fn cleanup_retention_zero_keeps_articles() {
 #[tokio::test]
 async fn cleanup_expires_header() {
     use chrono::Duration as ChronoDuration;
-    let cfg: Config = toml::from_str("port=1199\ndefault_retention_days=10").unwrap();
+    let cfg: Config = toml::from_str("port=119\ndefault_retention_days=10").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
     let past = (chrono::Utc::now() - ChronoDuration::days(1)).to_rfc2822();

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -13,7 +13,7 @@ async fn tls_quit() {
             .await
             .unwrap(),
     );
-    let (addr, cert, _h) = common::setup_tls_server(storage, auth).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage, auth).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -32,7 +32,7 @@ async fn tls_mode_reader() {
             .await
             .unwrap(),
     );
-    let (addr, cert, _h) = common::setup_tls_server(storage, auth).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage, auth).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -51,7 +51,7 @@ async fn tls_post_requires_auth() {
             .unwrap(),
     );
     storage.add_group("misc", false).await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -84,7 +84,7 @@ async fn tls_authinfo_and_post() {
     );
     storage.add_group("misc", false).await.unwrap();
     auth.add_user("user", "pass").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -142,7 +142,7 @@ async fn post_without_msgid_generates_one() {
     );
     storage.add_group("misc", false).await.unwrap();
     auth.add_user("user", "pass").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();
@@ -195,7 +195,7 @@ async fn post_without_date_adds_header() {
     );
     storage.add_group("misc", false).await.unwrap();
     auth.add_user("user", "pass").await.unwrap();
-    let (addr, cert, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
+    let (addr, cert, _pem, _h) = common::setup_tls_server(storage.clone(), auth.clone()).await;
     let (mut reader, mut writer) = common::connect_tls(addr, cert).await;
     let mut line = String::new();
     reader.read_line(&mut line).await.unwrap();


### PR DESCRIPTION
## Summary
- update NNTP port defaults and use TLS for peers
- verify peer certificates with system roots
- add serial tests for peer transfers
- provide helper PEM for TLS test servers

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68688bd9688c83269a5ca65319b562e7