### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/peers.rs
+++ b/src/peers.rs
@@ -124,10 +124,7 @@ impl PeerDb {
             if ts == 0 {
                 return Ok(None);
             }
-            Ok(Some(DateTime::<Utc>::from_naive_utc_and_offset(
-                chrono::NaiveDateTime::from_timestamp(ts, 0),
-                Utc,
-            )))
+            Ok(DateTime::<Utc>::from_timestamp(ts, 0))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
## Summary
- replace deprecated `NaiveDateTime::from_timestamp` call
- run tests to ensure everything still passes

## Testing
- `cargo test --quiet`
- `cargo check --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_6868932953c48326b7830ad4846cc945