### PR TITLE
Implement tokio_test client mock for RFC tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,6 +2860,7 @@ dependencies = [
  "renews",
  "tokio",
  "tokio-rustls",
+ "tokio-test",
  "toml",
 ]
 
@@ -2982,6 +3005,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -9,3 +9,4 @@ tokio-rustls = "0.24"
 rcgen = "0.14"
 toml = "0.8"
 renews = { path = ".." }
+tokio-test = "0.4"


### PR DESCRIPTION
## Summary
- add a ClientMock helper to `test_utils` using `tokio_test::io`
- create a helper setup and capability list in RFC tests
- refactor the first set of RFC end‑to‑end tests to use the new mock

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686896ba22108326ae97659f91a72d45