### PR TITLE
Add AUTHINFO credentials to peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ following keys are recognised:
 - `auth_db_path` - optional path to the authentication database. Defaults to `/var/renews/auth.db` when unset.
 - `peer_db_path` - path to the peer state database. Defaults to `/var/renews/peers.db`.
 - `peer_sync_secs` - default seconds between synchronizing with peers.
-- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged.
+- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged. Each peer may also specify optional `username` and `password` used for `AUTHINFO` when sending articles.
 - `tls_port` - optional port for NNTP over TLS.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
@@ -63,6 +63,8 @@ max_article_bytes = "2M"
 sitename = "peer.example.com"
 patterns = ["*"]
 sync_interval_secs = 3600
+username = "peeruser"
+password = "peerpass"
 ```
 
 `tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/config.toml
+++ b/config.toml
@@ -24,3 +24,5 @@ max_article_bytes = "2M"
 sitename = "peer.example.com"
 patterns = ["*"]
 sync_interval_secs = 3600
+username = "peeruser"
+password = "peerpass"

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,10 @@ pub struct PeerRule {
     pub patterns: Vec<String>,
     #[serde(default)]
     pub sync_interval_secs: Option<u64>,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
 }
 
 impl Config {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -78,3 +78,17 @@ fn default_paths() {
     assert_eq!(cfg.peer_db_path, "/var/renews/peers.db");
     assert_eq!(cfg.peer_sync_secs, 3600);
 }
+
+#[test]
+fn peer_auth_fields() {
+    let toml = r#"port = 119
+[[peers]]
+sitename = "news.example.com"
+username = "u"
+password = "p"
+"#;
+    let cfg: Config = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.peers.len(), 1);
+    assert_eq!(cfg.peers[0].username.as_deref(), Some("u"));
+    assert_eq!(cfg.peers[0].password.as_deref(), Some("p"));
+}

--- a/tests/peers.rs
+++ b/tests/peers.rs
@@ -1,12 +1,12 @@
 use renews::peers::{PeerConfig, PeerDb, peer_task};
 use renews::storage::Storage;
 use renews::storage::sqlite::SqliteStorage;
-use std::sync::Arc;
+use serial_test::serial;
 use std::fs;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::RwLock;
-use tempfile::NamedTempFile;
-use serial_test::serial;
 
 use test_utils as common;
 
@@ -32,6 +32,8 @@ async fn peer_task_updates_last_sync() {
         sitename: "127.0.0.1:9".into(),
         patterns: vec![],
         sync_interval_secs: Some(1),
+        username: None,
+        password: None,
     };
     let db_clone = db.clone();
     let storage_clone = storage.clone();
@@ -89,6 +91,8 @@ async fn peer_transfer_helper(interval: u64) {
         sitename: peer_name.clone(),
         patterns: vec!["*".into()],
         sync_interval_secs: Some(interval),
+        username: None,
+        password: None,
     };
     let db_clone = db.clone();
     let storage_clone = storage_a.clone();


### PR DESCRIPTION
## Summary
- allow specifying optional username and password for peers
- send AUTHINFO USER/PASS before transferring articles when credentials are given
- document and show example usage
- cover peer auth fields in tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68690e52e58c832693a9c60f7c546ce2