### PR TITLE
Fix newline handling in test mock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1461,6 +1461,7 @@ where
 {
     if let Some(id) = args.get(0) {
         if storage.get_article_by_id(id).await?.is_some() {
+            let _ = read_message(reader).await?;
             writer
                 .write_all(format!("439 {}\r\n", id).as_bytes())
                 .await?;

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -171,7 +171,11 @@ impl ClientMock {
         let mut builder = IoBuilder::new();
         builder.write(b"201 NNTP Service Ready - no posting allowed\r\n");
         for (cmd, resps) in self.steps {
-            builder.read(format!("{}\r\n", cmd).as_bytes());
+            let mut cmd_bytes = cmd.into_bytes();
+            if !cmd_bytes.ends_with(b"\n") {
+                cmd_bytes.extend_from_slice(b"\r\n");
+            }
+            builder.read(&cmd_bytes);
             for line in resps {
                 builder.write(format!("{}\r\n", line).as_bytes());
             }

--- a/tests/rfc_e2e.rs
+++ b/tests/rfc_e2e.rs
@@ -763,7 +763,6 @@ async fn ihave_example() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn takethis_example() {
     let (storage, auth) = setup().await;
     storage.add_group("misc.test", false).await.unwrap();


### PR DESCRIPTION
## Summary
- avoid leftover article data when TAKETHIS rejects an existing id
- ensure `takethis_example` test runs without ignore

## Testing
- `cargo test takethis_example -- --exact --nocapture`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68693df1058c8326834765451bc8256a