### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -181,7 +181,7 @@ pub mod sqlite {
             .bind(&msg_id)
             .bind(&headers)
             .bind(&article.body)
-            .bind(article.body.as_bytes().len() as i64)
+            .bind(article.body.len() as i64)
             .execute(&self.pool)
             .await?;
             let next: i64 = sqlx::query_scalar(


### PR DESCRIPTION
## Summary
- address clippy suggestions
- initialize `ConnectionState` with TLS flag
- remove unnecessary `as_bytes` calls

## Testing
- `cargo check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68699250d4948326a8d058f9eb0fa812