### PR TITLE
Refactor wildmat with regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ pgp = "0.16"
 rand = "0.8"
 base64 = "0.21"
 sha2 = "0.10"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/wildmat.rs
+++ b/src/wildmat.rs
@@ -1,92 +1,82 @@
+use regex::Regex;
+
 #[must_use]
 pub fn wildmat(pattern: &str, text: &str) -> bool {
-    fn inner(p: &[u8], t: &[u8]) -> bool {
-        if p.is_empty() {
-            return t.is_empty();
-        }
-        match p[0] {
-            b'?' => {
-                if t.is_empty() {
-                    false
+    if let Ok(re) = pattern_to_regex(pattern) {
+        re.is_match(text)
+    } else {
+        false
+    }
+}
+
+fn pattern_to_regex(pattern: &str) -> Result<Regex, regex::Error> {
+    let mut regex = String::from("^");
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '*' => regex.push_str(".*"),
+            '?' => regex.push('.'),
+            '[' => {
+                if let Some(class) = parse_class(&mut chars) {
+                    regex.push('[');
+                    regex.push_str(&class);
+                    regex.push(']');
                 } else {
-                    inner(&p[1..], &t[1..])
+                    regex.push_str("\\[");
                 }
             }
-            b'*' => {
-                if inner(&p[1..], t) {
-                    return true;
-                }
-                let mut i = 0;
-                while i < t.len() {
-                    if inner(&p[1..], &t[i + 1..]) {
-                        return true;
-                    }
-                    i += 1;
-                }
-                false
-            }
-            b'[' => {
-                if t.is_empty() {
-                    return false;
-                }
-                let mut i = 1;
-                let mut neg = false;
-                if i < p.len() && (p[i] == b'!' || p[i] == b'^') {
-                    neg = true;
-                    i += 1;
-                }
-                let mut matched = false;
-                let c = t[0];
-                let mut prev = 0u8;
-                let mut has_prev = false;
-                while i < p.len() {
-                    let pc = p[i];
-                    if pc == b']' && i != 1 + usize::from(neg) {
-                        break;
-                    }
-                    if pc == b'-' && has_prev && i + 1 < p.len() && p[i + 1] != b']' {
-                        let end = p[i + 1];
-                        if prev <= c && c <= end {
-                            matched = true;
-                        }
-                        i += 2;
-                        has_prev = false;
-                        continue;
-                    }
-                    if pc == c {
-                        matched = true;
-                    }
-                    prev = pc;
-                    has_prev = true;
-                    i += 1;
-                }
-                if i >= p.len() || p[i] != b']' {
-                    // unterminated class treated literally
-                    return !t.is_empty() && p[0] == t[0] && inner(&p[1..], &t[1..]);
-                }
-                if matched ^ neg {
-                    inner(&p[i + 1..], &t[1..])
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    regex.push_str(&regex::escape(&next.to_string()));
                 } else {
-                    false
+                    regex.push('\\');
                 }
             }
-            b'\\' => {
-                if p.len() >= 2 && !t.is_empty() && p[1] == t[0] {
-                    inner(&p[2..], &t[1..])
-                } else {
-                    false
-                }
-            }
-            _ => {
-                if !t.is_empty() && p[0] == t[0] {
-                    inner(&p[1..], &t[1..])
-                } else {
-                    false
-                }
-            }
+            _ => regex.push_str(&regex::escape(&c.to_string())),
         }
     }
-    inner(pattern.as_bytes(), text.as_bytes())
+    regex.push('$');
+    Regex::new(&regex)
+}
+
+fn parse_class<I>(chars: &mut std::iter::Peekable<I>) -> Option<String>
+where
+    I: Iterator<Item = char> + Clone,
+{
+    let mut preview = chars.clone();
+    let mut found = false;
+    while let Some(ch) = preview.next() {
+        if ch == ']' {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return None;
+    }
+
+    let mut class = String::new();
+    if let Some(&first) = chars.peek() {
+        if first == '!' || first == '^' {
+            class.push('^');
+            chars.next();
+        }
+    }
+    while let Some(ch) = chars.next() {
+        if ch == ']' {
+            break;
+        }
+        if ch == '\\' {
+            if let Some(next) = chars.next() {
+                class.push_str(&regex::escape(&next.to_string()));
+            } else {
+                class.push_str("\\");
+            }
+        } else {
+            class.push(ch);
+        }
+    }
+    Some(class)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace custom wildmat matching logic with a regex-based implementation
- add the `regex` crate dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a5e9e96908326a476fa1a147fe83c