### PR TITLE
Update ClientMock to support multi-line requests

### DIFF
--- a/tests/compliance.rs
+++ b/tests/compliance.rs
@@ -1,8 +1,8 @@
 use chrono::{Duration, Utc};
 #[path = "utils.rs"]
 mod utils;
-use utils::ClientMock;
 use renews::{parse_command, parse_message, parse_response};
+use utils::ClientMock;
 
 fn help_lines() -> Vec<String> {
     vec![
@@ -1128,9 +1128,9 @@ async fn ihave_example() {
             "IHAVE <i.am.an.article.you.will.want@example.com>",
             "335 Send it; end with <CR-LF>.<CR-LF>",
         )
-        .expect(
-            article.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .expect(
             "IHAVE <i.am.an.article.you.will.want@example.com>",
@@ -1178,13 +1178,13 @@ async fn takethis_example() {
         ".\r\n"
     );
     ClientMock::new()
-        .expect(
-            take_article.trim_end_matches("\r\n"),
-            "239 <i.am.an.article.new@example.com>",
+        .expect_request_multi(
+            utils::request_lines(take_article.trim_end_matches("\r\n")),
+            vec!["239 <i.am.an.article.new@example.com>"],
         )
-        .expect(
-            take_reject.trim_end_matches("\r\n"),
-            "439 <i.am.an.article.you.have@example.com>",
+        .expect_request_multi(
+            utils::request_lines(take_reject.trim_end_matches("\r\n")),
+            vec!["439 <i.am.an.article.you.have@example.com>"],
         )
         .run(storage, auth)
         .await;
@@ -1198,33 +1198,37 @@ async fn mode_stream_check_and_takethis() {
         .expect("MODE STREAM", "203 Streaming permitted")
         .expect("CHECK <stream1@test>", "238 <stream1@test>")
         .expect("CHECK <stream2@test>", "238 <stream2@test>")
-        .expect(
-            concat!(
-                "TAKETHIS <stream1@test>\r\n",
-                "Newsgroups: misc.test\r\n",
-                "From: a@test\r\n",
-                "Subject: one\r\n",
-                "Message-ID: <stream1@test>\r\n",
-                "\r\n",
-                "Body one\r\n",
-                ".\r\n"
-            )
-            .trim_end_matches("\r\n"),
-            "239 <stream1@test>",
+        .expect_request_multi(
+            utils::request_lines(
+                concat!(
+                    "TAKETHIS <stream1@test>\r\n",
+                    "Newsgroups: misc.test\r\n",
+                    "From: a@test\r\n",
+                    "Subject: one\r\n",
+                    "Message-ID: <stream1@test>\r\n",
+                    "\r\n",
+                    "Body one\r\n",
+                    ".\r\n"
+                )
+                .trim_end_matches("\r\n"),
+            ),
+            vec!["239 <stream1@test>"],
         )
-        .expect(
-            concat!(
-                "TAKETHIS <stream2@test>\r\n",
-                "Newsgroups: misc.test\r\n",
-                "From: b@test\r\n",
-                "Subject: two\r\n",
-                "Message-ID: <stream2@test>\r\n",
-                "\r\n",
-                "Body two\r\n",
-                ".\r\n"
-            )
-            .trim_end_matches("\r\n"),
-            "239 <stream2@test>",
+        .expect_request_multi(
+            utils::request_lines(
+                concat!(
+                    "TAKETHIS <stream2@test>\r\n",
+                    "Newsgroups: misc.test\r\n",
+                    "From: b@test\r\n",
+                    "Subject: two\r\n",
+                    "Message-ID: <stream2@test>\r\n",
+                    "\r\n",
+                    "Body two\r\n",
+                    ".\r\n"
+                )
+                .trim_end_matches("\r\n"),
+            ),
+            vec!["239 <stream2@test>"],
         )
         .expect("CHECK <stream1@test>", "438 <stream1@test>")
         .expect("CHECK <stream2@test>", "438 <stream2@test>")

--- a/tests/integration/cancel_lock.rs
+++ b/tests/integration/cancel_lock.rs
@@ -24,9 +24,9 @@ async fn cancel_key_allows_cancel() {
     );
     ClientMock::new()
         .expect("IHAVE <c@test>", "335 Send it; end with <CR-LF>.<CR-LF>")
-        .expect(
-            cancel.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(cancel.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .run(storage.clone(), auth)
         .await;

--- a/tests/integration/control.rs
+++ b/tests/integration/control.rs
@@ -25,9 +25,7 @@ fn build_control_article(cmd: &str, body: &str) -> String {
     } else {
         "\r\n.\r\n"
     };
-    format!(
-        "{headers}Newsgroups: test.group\r\n{xhdr}\r\n\r\n{body}{term}"
-    )
+    format!("{headers}Newsgroups: test.group\r\n{xhdr}\r\n\r\n{body}{term}")
 }
 
 #[tokio::test]
@@ -41,9 +39,9 @@ async fn control_newgroup_and_rmgroup() {
     let article = build_control_article("newgroup test.group", "test group body\n");
     ClientMock::new()
         .expect("IHAVE <ctrl@test>", "335 Send it; end with <CR-LF>.<CR-LF>")
-        .expect(
-            article.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .run(storage.clone(), auth.clone())
         .await;
@@ -61,9 +59,9 @@ async fn control_newgroup_and_rmgroup() {
             "IHAVE <ctrl2@test>",
             "335 Send it; end with <CR-LF>.<CR-LF>",
         )
-        .expect(
-            article.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .run(storage.clone(), auth.clone())
         .await;
@@ -92,9 +90,9 @@ async fn control_cancel_removes_article() {
     let article = build_control_article("cancel <a@test>", "cancel\n");
     ClientMock::new()
         .expect("IHAVE <c@test>", "335 Send it; end with <CR-LF>.<CR-LF>")
-        .expect(
-            article.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .run(storage.clone(), auth)
         .await;
@@ -134,9 +132,9 @@ async fn admin_cancel_ignores_lock() {
     let article = build_control_article("cancel <al@test>", "cancel\n");
     ClientMock::new()
         .expect("IHAVE <c2@test>", "335 Send it; end with <CR-LF>.<CR-LF>")
-        .expect(
-            article.trim_end_matches("\r\n"),
-            "235 Article transferred OK",
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["235 Article transferred OK"],
         )
         .run(storage.clone(), auth)
         .await;

--- a/tests/integration/moderated.rs
+++ b/tests/integration/moderated.rs
@@ -57,9 +57,7 @@ fn build_cross_article() -> String {
         x2.push_str("\r\n ");
         x2.push_str(l);
     }
-    format!(
-        "{base}Approved: mod1\r\nApproved: mod2\r\n{x1}\r\n{x2}\r\n\r\nBody\r\n.\r\n"
-    )
+    format!("{base}Approved: mod1\r\nApproved: mod2\r\n{x1}\r\n{x2}\r\n\r\nBody\r\n.\r\n")
 }
 
 #[tokio::test]
@@ -116,7 +114,10 @@ async fn post_with_approval_succeeds() {
             "POST",
             "340 send article to be posted. End with <CR-LF>.<CR-LF>",
         )
-        .expect(article.trim_end_matches("\r\n"), "240 article received")
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["240 article received"],
+        )
         .run_tls(storage.clone(), auth)
         .await;
     assert!(
@@ -150,7 +151,10 @@ async fn cross_post_different_moderators() {
             "POST",
             "340 send article to be posted. End with <CR-LF>.<CR-LF>",
         )
-        .expect(article.trim_end_matches("\r\n"), "240 article received")
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["240 article received"],
+        )
         .run_tls(storage.clone(), auth)
         .await;
     assert_eq!(

--- a/tests/integration/tls.rs
+++ b/tests/integration/tls.rs
@@ -60,7 +60,10 @@ async fn tls_authinfo_and_post() {
             "POST",
             "340 send article to be posted. End with <CR-LF>.<CR-LF>",
         )
-        .expect(article.trim_end_matches("\r\n"), "240 article received")
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["240 article received"],
+        )
         .expect("QUIT", "205 closing connection")
         .run_tls(storage.clone(), auth)
         .await;
@@ -95,16 +98,17 @@ async fn post_without_msgid_generates_one() {
             "POST",
             "340 send article to be posted. End with <CR-LF>.<CR-LF>",
         )
-        .expect(article.trim_end_matches("\r\n"), "240 article received")
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["240 article received"],
+        )
         .run_tls(storage.clone(), auth.clone())
         .await;
     use sha1::{Digest, Sha1};
     let hash = Sha1::digest(b"Body\r\n");
     let id = format!(
         "<{}>",
-        hash.iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>()
+        hash.iter().map(|b| format!("{b:02x}")).collect::<String>()
     );
     assert!(storage.get_article_by_id(&id).await.unwrap().is_some());
 }
@@ -131,16 +135,17 @@ async fn post_without_date_adds_header() {
             "POST",
             "340 send article to be posted. End with <CR-LF>.<CR-LF>",
         )
-        .expect(article.trim_end_matches("\r\n"), "240 article received")
+        .expect_request_multi(
+            utils::request_lines(article.trim_end_matches("\r\n")),
+            vec!["240 article received"],
+        )
         .run_tls(storage.clone(), auth.clone())
         .await;
     use sha1::{Digest, Sha1};
     let hash = Sha1::digest(b"Body\r\n");
     let id = format!(
         "<{}>",
-        hash.iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>()
+        hash.iter().map(|b| format!("{b:02x}")).collect::<String>()
     );
     let msg = storage.get_article_by_id(&id).await.unwrap().unwrap();
     let date = msg


### PR DESCRIPTION
## Summary
- extend `ClientMock` with `request_lines` helper to split multi-line requests
- replace multi-line string expectations with `expect_request_multi`

## Testing
- `cargo test mode_reader_success -- --test-threads=1 --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686a78d61c1083268536aa929488d2c8