### PR TITLE
Move server setup outside of client mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "rand",
  "rand_core",
  "rcgen",
+ "regex",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",


### PR DESCRIPTION
## Summary
- move server startup logic to standalone helpers
- keep `ClientMock` as client driver and call helpers from wrapper methods

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686abdbc8b488326adf7f35715c6ae15