### PR TITLE
Add init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ renews admin add-moderator alice 'rust.*'
 # remove moderator permissions
 renews admin remove-moderator alice 'rust.*'
 ```
+
+Use `--init` to create the article, authentication and peer state databases
+without starting the server:
+
+```bash
+renews --init --config /opt/renews/config.toml
+```


### PR DESCRIPTION
## Summary
- rename `init-db` CLI command to `init` via a new `--init` flag
- document the new flag for initializing databases without running the server

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_686b32b72e248326ad8108a24d577ce9