### PR TITLE
Switch to listen addresses in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Configuration is loaded from the file specified with `--config`. When the
 otherwise `/etc/renews.toml` is assumed. The
 following keys are recognised:
 
-- `port` - TCP port for plain NNTP connections.
+- `addr` - listen address for plain NNTP connections. If the host portion is
+  omitted the server listens on all interfaces.
 - `site_name` - hostname advertised by the server. Defaults to the `HOSTNAME`
   environment variable or `localhost` when unset.
 - `db_path` - database connection string for storing articles. Defaults to
@@ -29,10 +30,12 @@ following keys are recognised:
   `sqlite:///var/renews/peers.db`.
 - `peer_sync_secs` - default seconds between synchronizing with peers.
 - `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged. Each peer may also specify optional `username` and `password` used for `AUTHINFO` when sending articles.
-- `tls_port` - optional port for NNTP over TLS.
+- `tls_addr` - optional listen address for NNTP over TLS. Omitting the host
+  portion listens on all interfaces.
 - `tls_cert` - path to the TLS certificate in PEM format.
 - `tls_key` - path to the TLS private key in PEM format.
-- `ws_port` - optional port for the WebSocket bridge (requires the `websocket` feature).
+- `ws_addr` - optional listen address for the WebSocket bridge (requires the
+  `websocket` feature). Omitting the host portion listens on all interfaces.
 - `default_retention_days` - default number of days to keep articles.
 - `default_max_article_bytes` - default maximum article size in bytes. A `K`,
   `M` or `G` suffix may be used to specify kilobytes, megabytes or gigabytes.
@@ -42,16 +45,16 @@ following keys are recognised:
 An example configuration is provided in the repository:
 
 ```toml
-port = 119
+addr = ":119"
 site_name = "example.com"
 db_path = "sqlite:///var/renews/news.db"
 auth_db_path = "sqlite:///var/renews/auth.db"
 peer_db_path = "sqlite:///var/renews/peers.db"
 peer_sync_secs = 3600
-tls_port = 563
+tls_addr = ":563"
 tls_cert = "cert.pem"
 tls_key = "key.pem"
-ws_port = 8080
+ws_addr = ":8080"
 default_retention_days = 30
 default_max_article_bytes = "1M"
 
@@ -72,8 +75,8 @@ username = "peeruser"
 password = "peerpass"
 ```
 
-`tls_port`, `tls_cert` and `tls_key` must all be set for TLS support to be
-enabled. The WebSocket bridge is started when `ws_port` is set and the crate is
+`tls_addr`, `tls_cert` and `tls_key` must all be set for TLS support to be
+enabled. The WebSocket bridge is started when `ws_addr` is set and the crate is
 compiled with the `websocket` feature.
 
 ## Deployment with systemd

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,10 @@
-port = 119
+addr = ":119"
 site_name = "example.com"
 db_path = "sqlite:///var/renews/news.db"
 auth_db_path = "sqlite:///var/renews/auth.db"
 peer_db_path = "sqlite:///var/renews/peers.db"
 peer_sync_secs = 3600
-tls_port = 563
+tls_addr = ":563"
 tls_cert = "cert.pem"
 tls_key = "key.pem"
 default_retention_days = 30

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ where
 
 #[derive(Deserialize, Clone)]
 pub struct Config {
-    pub port: u16,
+    pub addr: String,
     #[serde(default = "default_site_name")]
     pub site_name: String,
     #[serde(default = "default_db_path")]
@@ -109,13 +109,13 @@ pub struct Config {
     #[serde(default)]
     pub peers: Vec<PeerRule>,
     #[serde(default)]
-    pub tls_port: Option<u16>,
+    pub tls_addr: Option<String>,
     #[serde(default)]
     pub tls_cert: Option<String>,
     #[serde(default)]
     pub tls_key: Option<String>,
     #[serde(default)]
-    pub ws_port: Option<u16>,
+    pub ws_addr: Option<String>,
     #[serde(default)]
     pub default_retention_days: Option<i64>,
     #[serde(default, deserialize_with = "deserialize_size")]
@@ -206,6 +206,6 @@ impl Config {
         self.peers = other.peers;
         self.tls_cert = other.tls_cert;
         self.tls_key = other.tls_key;
-        self.ws_port = other.ws_port;
+        self.ws_addr = other.ws_addr;
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_rustls::{TlsAcceptor, rustls};
 use tracing::{error, info};
+use std::net::SocketAddr;
 
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::RwLock;
@@ -41,6 +42,17 @@ fn load_tls_config(
         .with_single_cert(certs, key)?;
     Ok(config)
 }
+
+fn listen_addr(raw: &str) -> String {
+    if raw.parse::<SocketAddr>().is_ok() {
+        raw.to_string()
+    } else if let Some(port) = raw.strip_prefix(':') {
+        format!("0.0.0.0:{port}")
+    } else {
+        format!("0.0.0.0:{raw}")
+    }
+}
+
 
 #[allow(clippy::too_many_lines)]
 pub async fn run(
@@ -90,7 +102,7 @@ pub async fn run(
     }
     let addr = {
         let cfg_guard = cfg.read().await;
-        format!("127.0.0.1:{}", cfg_guard.port)
+        listen_addr(&cfg_guard.addr)
     };
     info!("listening on {addr}");
     let listener = TcpListener::bind(&addr).await?;
@@ -114,12 +126,12 @@ pub async fn run(
 
     {
         let cfg_guard = cfg.read().await;
-        if let (Some(tls_port), Some(cert), Some(key)) = (
-            cfg_guard.tls_port,
+        if let (Some(tls_addr_raw), Some(cert), Some(key)) = (
+            cfg_guard.tls_addr.as_deref(),
             cfg_guard.tls_cert.as_ref(),
             cfg_guard.tls_key.as_ref(),
         ) {
-            let tls_addr = format!("127.0.0.1:{tls_port}");
+            let tls_addr = listen_addr(tls_addr_raw);
             info!("listening TLS on {tls_addr}");
             let tls_listener = TcpListener::bind(&tls_addr).await?;
             let acceptor = TlsAcceptor::from(Arc::new(load_tls_config(cert, key)?));
@@ -157,8 +169,8 @@ pub async fn run(
         #[cfg(feature = "websocket")]
         {
             let cfg_ws = cfg.clone();
-            if let Some(port) = cfg.read().await.ws_port {
-                info!("websocket bridge on 127.0.0.1:{port}");
+            if let Some(addr_raw) = cfg.read().await.ws_addr.as_deref() {
+                info!("websocket bridge on {addr_raw}");
                 tokio::spawn(async move {
                     if let Err(e) = ws::run_ws_bridge(cfg_ws).await {
                         error!("websocket error: {e}");

--- a/tests/integration/max_size.rs
+++ b/tests/integration/max_size.rs
@@ -9,7 +9,7 @@ async fn ihave_rejects_large_article() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
     let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
-        toml::from_str("port=119\ndefault_max_article_bytes=10\n").unwrap(),
+        toml::from_str("addr=\":119\"\ndefault_max_article_bytes=10\n").unwrap(),
     ));
     let cfg_val = cfg.read().await.clone();
     ClientMock::new()
@@ -34,7 +34,7 @@ async fn ihave_rejects_large_article_with_suffix() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
     let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(
-        toml::from_str("port=119\ndefault_max_article_bytes=\"1K\"\n").unwrap(),
+        toml::from_str("addr=\":119\"\ndefault_max_article_bytes=\"1K\"\n").unwrap(),
     ));
     let cfg_val = cfg.read().await.clone();
     ClientMock::new()

--- a/tests/integration/peers.rs
+++ b/tests/integration/peers.rs
@@ -57,8 +57,8 @@ async fn peer_transfer_helper(interval: u64) {
     );
     auth.add_user("user", "pass").await.unwrap();
 
-    let cfg_a: renews::config::Config = toml::from_str("port=119\nsite_name='A'").unwrap();
-    let cfg_b: renews::config::Config = toml::from_str("port=119").unwrap();
+    let cfg_a: renews::config::Config = toml::from_str("addr=\":119\"\nsite_name='A'").unwrap();
+    let cfg_b: renews::config::Config = toml::from_str("addr=\":119\"").unwrap();
     let (addr_b, cert_b, handle_b) =
         common::start_server(storage_b.clone(), auth.clone(), cfg_b.clone(), true).await;
     let ca_file = NamedTempFile::new().unwrap();

--- a/tests/integration/retention.rs
+++ b/tests/integration/retention.rs
@@ -10,7 +10,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn cleanup_retention_zero_keeps_articles() {
-    let cfg: Config = toml::from_str("port=119\ndefault_retention_days=0").unwrap();
+    let cfg: Config = toml::from_str("addr=\":119\"\ndefault_retention_days=0").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
     let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
@@ -29,7 +29,7 @@ async fn cleanup_retention_zero_keeps_articles() {
 #[tokio::test]
 async fn cleanup_expires_header() {
     use chrono::Duration as ChronoDuration;
-    let cfg: Config = toml::from_str("port=119\ndefault_retention_days=10").unwrap();
+    let cfg: Config = toml::from_str("addr=\":119\"\ndefault_retention_days=10").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
     let past = (chrono::Utc::now() - ChronoDuration::days(1)).to_rfc2822();

--- a/tests/integration/ws.rs
+++ b/tests/integration/ws.rs
@@ -19,10 +19,10 @@ mod websocket_bridge {
     async fn quit_via_websocket() {
         let (storage, auth) = utils::setup().await;
         let (nntp_addr, _, nntp_handle) =
-            utils::start_server(storage, auth, toml::from_str("port=119").unwrap(), false).await;
+            utils::start_server(storage, auth, toml::from_str("addr=\":119\"").unwrap(), false).await;
         let ws_port = free_port();
         let cfg: Config =
-            toml::from_str(&format!("port={}\nws_port={}", nntp_addr.port(), ws_port)).unwrap();
+            toml::from_str(&format!("addr=\"127.0.0.1:{}\"\nws_addr=\":{}\"", nntp_addr.port(), ws_port)).unwrap();
         let cfg = Arc::new(RwLock::new(cfg));
         let ws_handle = tokio::spawn(ws::run_ws_bridge(cfg));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -2,7 +2,7 @@ use renews::config::Config;
 
 #[test]
 fn retention_rules_match() {
-    let toml = r#"port = 119
+    let toml = r#"addr = ":119"
 default_retention_days = 10
 default_max_article_bytes = "1K"
 [[group_settings]]
@@ -24,12 +24,12 @@ max_article_bytes = "20K"
 
 #[test]
 fn runtime_update_preserves_immutable_fields() {
-    let initial = r#"port = 119
+    let initial = r#"addr = ":119"
 db_path = "/tmp/db1"
 auth_db_path = "/tmp/auth1"
 peer_db_path = "/tmp/peer1"
 peer_sync_secs = 1800
-tls_port = 563
+tls_addr = ":563"
 tls_cert = "old.pem"
 tls_key = "old.key"
 default_retention_days = 10
@@ -40,12 +40,12 @@ retention_days = 5
 "#;
     let mut cfg: Config = toml::from_str(initial).unwrap();
 
-    let updated = r#"port = 42
+    let updated = r#"addr = ":42"
 db_path = "/tmp/db2"
 auth_db_path = "/tmp/auth2"
 peer_db_path = "/tmp/peer2"
 peer_sync_secs = 3600
-tls_port = 9999
+tls_addr = ":9999"
 tls_cert = "new.pem"
 tls_key = "new.key"
 default_retention_days = 1
@@ -57,12 +57,12 @@ retention_days = 1
     let new_cfg: Config = toml::from_str(updated).unwrap();
     cfg.update_runtime(new_cfg);
 
-    assert_eq!(cfg.port, 119);
+    assert_eq!(cfg.addr, ":119");
     assert_eq!(cfg.db_path, "/tmp/db1");
     assert_eq!(cfg.auth_db_path, "/tmp/auth1");
     assert_eq!(cfg.peer_db_path, "/tmp/peer1");
     assert_eq!(cfg.peer_sync_secs, 3600);
-    assert_eq!(cfg.tls_port, Some(563));
+    assert_eq!(cfg.tls_addr.as_deref(), Some(":563"));
     assert_eq!(cfg.tls_cert.as_deref(), Some("new.pem"));
     assert_eq!(cfg.tls_key.as_deref(), Some("new.key"));
     assert_eq!(cfg.default_retention_days, Some(1));
@@ -72,7 +72,7 @@ retention_days = 1
 
 #[test]
 fn default_paths() {
-    let cfg: Config = toml::from_str("port=119").unwrap();
+    let cfg: Config = toml::from_str("addr=\":119\"").unwrap();
     assert_eq!(cfg.db_path, "sqlite:///var/renews/news.db");
     assert_eq!(cfg.auth_db_path, "sqlite:///var/renews/auth.db");
     assert_eq!(cfg.peer_db_path, "sqlite:///var/renews/peers.db");
@@ -81,7 +81,7 @@ fn default_paths() {
 
 #[test]
 fn peer_auth_fields() {
-    let toml = r#"port = 119
+    let toml = r#"addr = ":119"
 [[peers]]
 sitename = "news.example.com"
 username = "u"

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -99,7 +99,7 @@ pub async fn setup_server(
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
     let auth_clone = auth.clone();
-    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("port=119").unwrap()));
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("addr=\":119\"").unwrap()));
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
         handle_client(sock, store_clone, auth_clone, cfg, false)
@@ -154,7 +154,7 @@ pub async fn setup_tls_server_with_cert(
     let addr = listener.local_addr().unwrap();
     let store_clone = storage.clone();
     let auth_clone = auth.clone();
-    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("port=119").unwrap()));
+    let cfg: Arc<RwLock<Config>> = Arc::new(RwLock::new(toml::from_str("addr=\":119\"").unwrap()));
     let handle = tokio::spawn(async move {
         let (sock, _) = listener.accept().await.unwrap();
         let stream = acceptor.accept(sock).await.unwrap();
@@ -250,7 +250,7 @@ pub async fn run_client(
 ) {
     run_client_with_cfg(
         client,
-        toml::from_str("port=119").unwrap(),
+        toml::from_str("addr=\":119\"").unwrap(),
         storage,
         auth,
         false,
@@ -265,7 +265,7 @@ pub async fn run_client_tls(
 ) {
     run_client_with_cfg(
         client,
-        toml::from_str("port=119").unwrap(),
+        toml::from_str("addr=\":119\"").unwrap(),
         storage,
         auth,
         true,


### PR DESCRIPTION
## Summary
- replace `port`, `tls_port`, and `ws_port` config values with `addr`, `tls_addr`, and `ws_addr`
- update server and websocket code to parse listen addresses
- update documentation, example config, and tests

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc873b64c8326bf07a89a506ea148