### PR TITLE
Enable Postgres auth with credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ following keys are recognised:
 - `db_path` - database connection string for storing articles. Defaults to
   `sqlite:///var/renews/news.db`.
 - `auth_db_path` - authentication database connection string such as
-  `sqlite:///var/renews/auth.db` or `postgres://127.0.0.1:5432`. Defaults to
+  `sqlite:///var/renews/auth.db` or `postgres://user:pass@127.0.0.1:5432`.
+  When a PostgreSQL URI includes a username and password these are used for
+  authentication. Defaults to
   `sqlite:///var/renews/auth.db` when unset.
 - `peer_db_path` - connection string for the peer state database. Defaults to
   `sqlite:///var/renews/peers.db`.


### PR DESCRIPTION
## Summary
- mention optional username/password in documentation
- parse Postgres URIs with `PgConnectOptions`

## Testing
- `cargo test --features postgres`

------
https://chatgpt.com/codex/tasks/task_e_686bea4b40288326a9a5354d4734ecdc