### PR TITLE
Allow credentials in peer connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ following keys are recognised:
 - `peer_db_path` - connection string for the peer state database. Defaults to
   `sqlite:///var/renews/peers.db`.
 - `peer_sync_secs` - default seconds between synchronizing with peers.
-- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged. Each peer may also specify optional `username` and `password` used for `AUTHINFO` when sending articles.
+- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged. The `sitename` may include credentials in the form `user:pass@host:port` which are used for `AUTHINFO` when connecting.
 - `tls_addr` - optional listen address for NNTP over TLS. Omitting the host
   portion listens on all interfaces.
 - `tls_cert` - path to the TLS certificate in PEM format.
@@ -71,11 +71,9 @@ retention_days = 60
 max_article_bytes = "2M"
 
 [[peers]]
-sitename = "peer.example.com"
+sitename = "peeruser:peerpass@peer.example.com"
 patterns = ["*"]
 sync_interval_secs = 3600
-username = "peeruser"
-password = "peerpass"
 ```
 
 `tls_addr`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/config.toml
+++ b/config.toml
@@ -21,8 +21,6 @@ retention_days = 60
 max_article_bytes = "2M"
 
 [[peers]]
-sitename = "peer.example.com"
+sitename = "peeruser:peerpass@peer.example.com"
 patterns = ["*"]
 sync_interval_secs = 3600
-username = "peeruser"
-password = "peerpass"

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,10 +143,6 @@ pub struct PeerRule {
     pub patterns: Vec<String>,
     #[serde(default)]
     pub sync_interval_secs: Option<u64>,
-    #[serde(default)]
-    pub username: Option<String>,
-    #[serde(default)]
-    pub password: Option<String>,
 }
 
 impl Config {

--- a/tests/integration/peers.rs
+++ b/tests/integration/peers.rs
@@ -30,8 +30,6 @@ async fn peer_task_updates_last_sync() {
         sitename: "127.0.0.1:9".into(),
         patterns: vec![],
         sync_interval_secs: Some(1),
-        username: None,
-        password: None,
     };
     let db_clone = db.clone();
     let storage_clone = storage.clone();
@@ -102,8 +100,6 @@ async fn peer_transfer_helper(interval: u64) {
         sitename: peer_name.clone(),
         patterns: vec!["*".into()],
         sync_interval_secs: Some(interval),
-        username: None,
-        password: None,
     };
     let db_clone = db.clone();
     let storage_clone = storage_a.clone();

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -80,15 +80,12 @@ fn default_paths() {
 }
 
 #[test]
-fn peer_auth_fields() {
+fn peer_connection_string_allows_credentials() {
     let toml = r#"addr = ":119"
 [[peers]]
-sitename = "news.example.com"
-username = "u"
-password = "p"
+sitename = "u:p@news.example.com:563"
 "#;
     let cfg: Config = toml::from_str(toml).unwrap();
     assert_eq!(cfg.peers.len(), 1);
-    assert_eq!(cfg.peers[0].username.as_deref(), Some("u"));
-    assert_eq!(cfg.peers[0].password.as_deref(), Some("p"));
+    assert_eq!(cfg.peers[0].sitename, "u:p@news.example.com:563");
 }


### PR DESCRIPTION
## Summary
- remove username/password fields from `PeerRule`
- support credentials in peer connection string
- update docs and example configuration
- adjust tests for new config format

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bedcf16cc832687d663a85a07d925