### PR TITLE
Support config variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ following keys are recognised:
 - `group_settings` - list of per-group rules which can match a `group` exactly or a
   `pattern` using wildmat syntax to override retention and size defaults.
 
+Values inside the configuration may reference environment variables or other files.
+The pattern `$ENV{VAR}` is replaced by the value of the `VAR` environment variable
+and `$FILE{path}` is replaced with the contents of the file at `path` before the
+file is parsed.
+
 An example configuration is provided in the repository:
 
 ```toml


### PR DESCRIPTION
## Summary
- add environment and file placeholder expansion in config reader
- test new config substitutions
- document placeholder syntax in README

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686c014298e8832680b2af2cf9ad8f52