### PR TITLE
Refactor article storage to support multiple newsgroups

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use clap::{Parser, Subcommand};
 
-use renews::auth::{self, AuthProvider};
+use renews::auth;
 use renews::config::Config;
 use renews::server;
 use renews::storage;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5,12 +5,8 @@ use std::sync::Arc;
 
 #[async_trait]
 pub trait Storage: Send + Sync {
-    /// Store `article` in `group` returning the assigned article number
-    async fn store_article(
-        &self,
-        group: &str,
-        article: &Message,
-    ) -> Result<u64, Box<dyn Error + Send + Sync>>;
+    /// Store `article` and associate it with all groups specified in the Newsgroups header
+    async fn store_article(&self, article: &Message) -> Result<(), Box<dyn Error + Send + Sync>>;
 
     /// Retrieve an article by group name and article number
     async fn get_article_by_number(

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -75,13 +75,11 @@ impl SqliteStorage {
 #[async_trait]
 impl Storage for SqliteStorage {
     #[tracing::instrument(skip_all)]
-    async fn store_article(
-        &self,
-        group: &str,
-        article: &Message,
-    ) -> Result<u64, Box<dyn Error + Send + Sync>> {
+    async fn store_article(&self, article: &Message) -> Result<(), Box<dyn Error + Send + Sync>> {
         let msg_id = Self::message_id(article).ok_or("missing Message-ID")?;
         let headers = serde_json::to_string(&Headers(article.headers.clone()))?;
+
+        // Store the message once
         sqlx::query(
             "INSERT OR IGNORE INTO messages (message_id, headers, body, size) VALUES (?, ?, ?, ?)",
         )
@@ -91,23 +89,43 @@ impl Storage for SqliteStorage {
         .bind(i64::try_from(article.body.len()).unwrap_or(i64::MAX))
         .execute(&self.pool)
         .await?;
-        let next: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(MAX(number),0)+1 FROM group_articles WHERE group_name = ?",
-        )
-        .bind(group)
-        .fetch_one(&self.pool)
-        .await?;
+
+        // Extract newsgroups from headers
+        let newsgroups: Vec<String> = article
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("Newsgroups"))
+            .map(|(_, v)| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Associate with each group
         let now = chrono::Utc::now().timestamp();
-        sqlx::query(
-            "INSERT INTO group_articles (group_name, number, message_id, inserted_at) VALUES (?, ?, ?, ?)",
-        )
-        .bind(group)
-        .bind(next)
-        .bind(&msg_id)
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-        Ok(u64::try_from(next).unwrap_or(0))
+        for group in newsgroups {
+            let next: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(number),0)+1 FROM group_articles WHERE group_name = ?",
+            )
+            .bind(&group)
+            .fetch_one(&self.pool)
+            .await?;
+
+            sqlx::query(
+                "INSERT INTO group_articles (group_name, number, message_id, inserted_at) VALUES (?, ?, ?, ?)",
+            )
+            .bind(&group)
+            .bind(next)
+            .bind(&msg_id)
+            .bind(now)
+            .execute(&self.pool)
+            .await?;
+        }
+
+        Ok(())
     }
 
     #[tracing::instrument(skip_all)]

--- a/src/wildmat.rs
+++ b/src/wildmat.rs
@@ -43,9 +43,9 @@ fn parse_class<I>(chars: &mut std::iter::Peekable<I>) -> Option<String>
 where
     I: Iterator<Item = char> + Clone,
 {
-    let mut preview = chars.clone();
+    let preview = chars.clone();
     let mut found = false;
-    while let Some(ch) = preview.next() {
+    for ch in preview {
         if ch == ']' {
             found = true;
             break;
@@ -70,7 +70,7 @@ where
             if let Some(next) = chars.next() {
                 class.push_str(&regex::escape(&next.to_string()));
             } else {
-                class.push_str("\\");
+                class.push('\\');
             }
         } else {
             class.push(ch);

--- a/tests/compliance.rs
+++ b/tests/compliance.rs
@@ -38,8 +38,10 @@ fn help_lines() -> Vec<String> {
 async fn head_and_list_commands() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: T\r\n\r\nBody").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nSubject: T\r\nNewsgroups: misc\r\n\r\nBody")
+            .unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     ClientMock::new()
         .expect("MODE READER", "201 Posting prohibited")
@@ -50,6 +52,7 @@ async fn head_and_list_commands() {
                 "221 1 <1@test> article headers follow",
                 "Message-ID: <1@test>",
                 "Subject: T",
+                "Newsgroups: misc",
                 ".",
             ],
         )
@@ -66,10 +69,10 @@ async fn head_and_list_commands() {
 async fn listgroup_and_navigation_commands() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
-    storage.store_article("misc", &m1).await.unwrap();
-    storage.store_article("misc", &m2).await.unwrap();
+    let (_, m1) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nA").unwrap();
+    let (_, m2) = parse_message("Message-ID: <2@test>\r\nNewsgroups: misc\r\n\r\nB").unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
 
     let future = Utc::now() + Duration::seconds(1);
     let date = future.format("%Y%m%d");
@@ -87,6 +90,7 @@ async fn listgroup_and_navigation_commands() {
             vec![
                 "221 1 <1@test> article headers follow",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc",
                 ".",
             ],
         )
@@ -138,8 +142,8 @@ async fn capabilities_and_misc_commands() {
 async fn no_group_returns_412() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     ClientMock::new()
         .expect("MODE READER", "201 Posting prohibited")
@@ -153,8 +157,8 @@ async fn no_group_returns_412() {
 async fn responses_include_number_and_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     ClientMock::new()
         .expect("MODE READER", "201 Posting prohibited")
@@ -164,6 +168,7 @@ async fn responses_include_number_and_id() {
             vec![
                 "221 1 <1@test> article headers follow",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc",
                 ".",
             ],
         )
@@ -177,6 +182,7 @@ async fn responses_include_number_and_id() {
             vec![
                 "220 1 <1@test> article follows",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc",
                 "",
                 "Body",
                 ".",
@@ -213,8 +219,10 @@ async fn post_and_dot_stuffing() {
 async fn body_returns_proper_crlf() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nline1\r\nline2\r\n").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nline1\r\nline2\r\n")
+            .unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     ClientMock::new()
         .expect("MODE READER", "201 Posting prohibited")
@@ -246,8 +254,8 @@ async fn newgroups_accepts_gmt_argument() {
 async fn newnews_accepts_gmt_argument() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     ClientMock::new()
         .expect("MODE READER", "201 Posting prohibited")
@@ -516,8 +524,9 @@ async fn group_select_returns_211() {
 async fn article_success_by_number() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect_multi(
@@ -525,6 +534,7 @@ async fn article_success_by_number() {
             vec![
                 "220 1 <1@test> article follows",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 "",
                 "Body",
                 ".",
@@ -538,14 +548,16 @@ async fn article_success_by_number() {
 async fn article_success_by_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "ARTICLE <1@test>",
             vec![
                 "220 0 <1@test> article follows",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 "",
                 "Body",
                 ".",
@@ -578,8 +590,9 @@ async fn article_number_no_group() {
 async fn head_success_by_number() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect_multi(
@@ -587,6 +600,7 @@ async fn head_success_by_number() {
             vec![
                 "221 1 <1@test> article headers follow",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 ".",
             ],
         )
@@ -598,14 +612,16 @@ async fn head_success_by_number() {
 async fn head_success_by_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "HEAD <1@test>",
             vec![
                 "221 0 <1@test> article headers follow",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 ".",
             ],
         )
@@ -617,8 +633,9 @@ async fn head_success_by_id() {
 async fn head_number_not_found() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect("HEAD 2", "423 no such article number in this group")
@@ -651,8 +668,9 @@ async fn head_no_current_article_selected() {
 async fn body_success_by_number() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect_multi(
@@ -667,8 +685,9 @@ async fn body_success_by_number() {
 async fn body_success_by_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "BODY <1@test>",
@@ -682,8 +701,9 @@ async fn body_success_by_id() {
 async fn body_number_not_found() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect("BODY 2", "423 no such article number in this group")
@@ -714,8 +734,9 @@ async fn body_number_no_group() {
 async fn stat_success_by_number() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect("STAT 1", "223 1 <1@test> article exists")
@@ -727,8 +748,9 @@ async fn stat_success_by_number() {
 async fn stat_success_by_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("STAT <1@test>", "223 0 <1@test> article exists")
         .run(storage, auth)
@@ -739,8 +761,9 @@ async fn stat_success_by_id() {
 async fn stat_number_not_found() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 1 1 1 misc.test")
         .expect("STAT 2", "423 no such article number in this group")
@@ -771,8 +794,9 @@ async fn stat_number_no_group() {
 async fn listgroup_returns_numbers() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "LISTGROUP misc.test",
@@ -862,8 +886,9 @@ async fn list_all_keywords() {
 async fn newnews_lists_recent_articles() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "NEWNEWS misc.test 19700101 000000",
@@ -877,8 +902,9 @@ async fn newnews_lists_recent_articles() {
 async fn newnews_no_matches_returns_empty() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nBody").unwrap();
+    storage.store_article(&msg).await.unwrap();
     use chrono::{Duration, Utc};
     let future = Utc::now() + Duration::seconds(1);
     let date = future.format("%Y%m%d");
@@ -896,8 +922,11 @@ async fn newnews_no_matches_returns_empty() {
 async fn hdr_subject_by_message_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) = parse_message(
+        "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: Hello\r\n\r\nBody",
+    )
+    .unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "HDR Subject <1@test>",
@@ -911,10 +940,14 @@ async fn hdr_subject_by_message_id() {
 async fn hdr_subject_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: A\r\n\r\nBody").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: B\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) =
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: A\r\n\r\nBody")
+            .unwrap();
+    let (_, m2) =
+        parse_message("Message-ID: <2@test>\r\nNewsgroups: misc.test\r\nSubject: B\r\n\r\nBody")
+            .unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -930,15 +963,16 @@ async fn hdr_all_headers_message_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
     let (_, msg) =
-        parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody")
+        parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: Hello\r\nFrom: a@test\r\n\r\nBody")
             .unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "HDR : <1@test>",
             vec![
                 "225 Headers follow",
                 "0 Message-ID: <1@test>",
+                "0 Newsgroups: misc.test",
                 "0 Subject: Hello",
                 "0 From: a@test",
                 ".",
@@ -952,8 +986,11 @@ async fn hdr_all_headers_message_id() {
 async fn xpat_subject_message_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) = parse_message(
+        "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: Hello\r\n\r\nBody",
+    )
+    .unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "XPAT Subject <1@test> *ell*",
@@ -967,10 +1004,16 @@ async fn xpat_subject_message_id() {
 async fn xpat_subject_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\nSubject: apple\r\n\r\nBody").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\nSubject: banana\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) = parse_message(
+        "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: apple\r\n\r\nBody",
+    )
+    .unwrap();
+    let (_, m2) = parse_message(
+        "Message-ID: <2@test>\r\nNewsgroups: misc.test\r\nSubject: banana\r\n\r\nBody",
+    )
+    .unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -985,9 +1028,11 @@ async fn xpat_subject_range() {
 async fn over_message_id() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, msg) =
-        parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    let (_, msg) = parse_message(
+        "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody",
+    )
+    .unwrap();
+    storage.store_article(&msg).await.unwrap();
     ClientMock::new()
         .expect_multi(
             "OVER <1@test>",
@@ -1005,12 +1050,16 @@ async fn over_message_id() {
 async fn over_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) =
-        parse_message("Message-ID: <1@test>\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody").unwrap();
-    let (_, m2) =
-        parse_message("Message-ID: <2@test>\r\nSubject: B\r\nFrom: b@test\r\n\r\nBody").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) = parse_message(
+        "Message-ID: <1@test>\r\nNewsgroups: misc.test\r\nSubject: A\r\nFrom: a@test\r\n\r\nBody",
+    )
+    .unwrap();
+    let (_, m2) = parse_message(
+        "Message-ID: <2@test>\r\nNewsgroups: misc.test\r\nSubject: B\r\nFrom: b@test\r\n\r\nBody",
+    )
+    .unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -1030,10 +1079,10 @@ async fn over_range() {
 async fn head_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nA").unwrap();
+    let (_, m2) = parse_message("Message-ID: <2@test>\r\nNewsgroups: misc.test\r\n\r\nB").unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -1041,9 +1090,11 @@ async fn head_range() {
             vec![
                 "221 1 <1@test> article headers follow",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 ".",
                 "221 2 <2@test> article headers follow",
                 "Message-ID: <2@test>",
+                "Newsgroups: misc.test",
                 ".",
             ],
         )
@@ -1055,10 +1106,10 @@ async fn head_range() {
 async fn body_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nA").unwrap();
+    let (_, m2) = parse_message("Message-ID: <2@test>\r\nNewsgroups: misc.test\r\n\r\nB").unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -1080,10 +1131,10 @@ async fn body_range() {
 async fn article_range() {
     let (storage, auth) = utils::setup().await;
     storage.add_group("misc.test", false).await.unwrap();
-    let (_, m1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
-    let (_, m2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
-    storage.store_article("misc.test", &m1).await.unwrap();
-    storage.store_article("misc.test", &m2).await.unwrap();
+    let (_, m1) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc.test\r\n\r\nA").unwrap();
+    let (_, m2) = parse_message("Message-ID: <2@test>\r\nNewsgroups: misc.test\r\n\r\nB").unwrap();
+    storage.store_article(&m1).await.unwrap();
+    storage.store_article(&m2).await.unwrap();
     ClientMock::new()
         .expect("GROUP misc.test", "211 2 1 2 misc.test")
         .expect_multi(
@@ -1091,11 +1142,13 @@ async fn article_range() {
             vec![
                 "220 1 <1@test> article follows",
                 "Message-ID: <1@test>",
+                "Newsgroups: misc.test",
                 "",
                 "A",
                 ".",
                 "220 2 <2@test> article follows",
                 "Message-ID: <2@test>",
+                "Newsgroups: misc.test",
                 "",
                 "B",
                 ".",
@@ -1108,12 +1161,12 @@ async fn article_range() {
 #[tokio::test]
 async fn ihave_example() {
     let (storage, auth) = utils::setup().await;
-    storage.add_group("misc.test", false).await.unwrap();
+    storage.add_group("misc.test.test", false).await.unwrap();
 
     let article = concat!(
         "Path: pathost!demo!somewhere!not-for-mail\r\n",
         "From: \"Demo User\" <nobody@example.com>\r\n",
-        "Newsgroups: misc.test\r\n",
+        "Newsgroups: misc.test.test\r\n",
         "Subject: I am just a test article\r\n",
         "Date: 6 Oct 1998 04:38:40 -0500\r\n",
         "Organization: An Example Com, San Jose, CA\r\n",
@@ -1143,18 +1196,18 @@ async fn ihave_example() {
 #[tokio::test]
 async fn takethis_example() {
     let (storage, auth) = utils::setup().await;
-    storage.add_group("misc.test", false).await.unwrap();
+    storage.add_group("misc.test.test", false).await.unwrap();
     let (_, exist) = parse_message(
-        "Message-ID: <i.am.an.article.you.have@example.com>\r\nNewsgroups: misc.test\r\n\r\nBody",
+        "Message-ID: <i.am.an.article.you.have@example.com>\r\nNewsgroups: misc.test.test\r\n\r\nBody",
     )
     .unwrap();
-    storage.store_article("misc.test", &exist).await.unwrap();
+    storage.store_article(&exist).await.unwrap();
 
     let take_article = concat!(
         "TAKETHIS <i.am.an.article.new@example.com>\r\n",
         "Path: pathost!demo!somewhere!not-for-mail\r\n",
         "From: \"Demo User\" <nobody@example.com>\r\n",
-        "Newsgroups: misc.test\r\n",
+        "Newsgroups: misc.test.test\r\n",
         "Subject: I am just a test article\r\n",
         "Date: 6 Oct 1998 04:38:40 -0500\r\n",
         "Organization: An Example Com, San Jose, CA\r\n",
@@ -1168,7 +1221,7 @@ async fn takethis_example() {
         "TAKETHIS <i.am.an.article.you.have@example.com>\r\n",
         "Path: pathost!demo!somewhere!not-for-mail\r\n",
         "From: \"Demo User\" <nobody@example.com>\r\n",
-        "Newsgroups: misc.test\r\n",
+        "Newsgroups: misc.test.test\r\n",
         "Subject: I am just a test article\r\n",
         "Date: 6 Oct 1998 04:38:40 -0500\r\n",
         "Organization: An Example Com, San Jose, CA\r\n",
@@ -1193,7 +1246,7 @@ async fn takethis_example() {
 #[tokio::test]
 async fn mode_stream_check_and_takethis() {
     let (storage, auth) = utils::setup().await;
-    storage.add_group("misc.test", false).await.unwrap();
+    storage.add_group("misc.test.test", false).await.unwrap();
     ClientMock::new()
         .expect("MODE STREAM", "203 Streaming permitted")
         .expect("CHECK <stream1@test>", "238 <stream1@test>")
@@ -1202,7 +1255,7 @@ async fn mode_stream_check_and_takethis() {
             utils::request_lines(
                 concat!(
                     "TAKETHIS <stream1@test>\r\n",
-                    "Newsgroups: misc.test\r\n",
+                    "Newsgroups: misc.test.test\r\n",
                     "From: a@test\r\n",
                     "Subject: one\r\n",
                     "Message-ID: <stream1@test>\r\n",
@@ -1218,7 +1271,7 @@ async fn mode_stream_check_and_takethis() {
             utils::request_lines(
                 concat!(
                     "TAKETHIS <stream2@test>\r\n",
-                    "Newsgroups: misc.test\r\n",
+                    "Newsgroups: misc.test.test\r\n",
                     "From: b@test\r\n",
                     "Subject: two\r\n",
                     "Message-ID: <stream2@test>\r\n",

--- a/tests/integration/cancel_lock.rs
+++ b/tests/integration/cancel_lock.rs
@@ -17,7 +17,7 @@ async fn cancel_key_allows_cancel() {
         "Message-ID: <a@test>\r\nNewsgroups: misc.test\r\nCancel-Lock: sha256:{lock_b64}\r\n\r\nBody"
     );
     let (_, msg) = parse_message(&orig).unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     let cancel = format!(
         "Message-ID: <c@test>\r\nNewsgroups: misc.test\r\nControl: cancel <a@test>\r\nCancel-Key: sha256:{key_b64}\r\n\r\n.\r\n"

--- a/tests/integration/control.rs
+++ b/tests/integration/control.rs
@@ -82,7 +82,7 @@ async fn control_cancel_removes_article() {
         "Message-ID: <a@test>\r\nNewsgroups: misc.test\r\nFrom: u@test\r\nSubject: t\r\n\r\nBody",
     )
     .unwrap();
-    storage.store_article("misc.test", &art).await.unwrap();
+    storage.store_article(&art).await.unwrap();
     auth.add_user("admin@example.org", "x").await.unwrap();
     auth.add_admin("admin@example.org", ADMIN_PUB)
         .await
@@ -121,7 +121,7 @@ async fn admin_cancel_ignores_lock() {
         "Message-ID: <al@test>\r\nNewsgroups: misc.test\r\nCancel-Lock: sha256:{lock_b64}\r\n\r\nBody"
     );
     let (_, msg) = parse_message(&orig).unwrap();
-    storage.store_article("misc.test", &msg).await.unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     // admin setup
     auth.add_user("admin@example.org", "x").await.unwrap();

--- a/tests/integration/retention.rs
+++ b/tests/integration/retention.rs
@@ -13,8 +13,8 @@ async fn cleanup_retention_zero_keeps_articles() {
     let cfg: Config = toml::from_str("addr=\":119\"\ndefault_retention_days=0").unwrap();
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nNewsgroups: misc\r\n\r\nB").unwrap();
+    storage.store_article(&msg).await.unwrap();
     sleep(StdDuration::from_secs(1)).await;
     cleanup_expired_articles(&*storage, &cfg).await.unwrap();
     assert!(
@@ -33,9 +33,9 @@ async fn cleanup_expires_header() {
     let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new("sqlite::memory:").await.unwrap());
     storage.add_group("misc", false).await.unwrap();
     let past = (chrono::Utc::now() - ChronoDuration::days(1)).to_rfc2822();
-    let text = format!("Message-ID: <2@test>\r\nExpires: {past}\r\n\r\nB");
+    let text = format!("Message-ID: <2@test>\r\nNewsgroups: misc\r\nExpires: {past}\r\n\r\nB");
     let (_, msg) = parse_message(&text).unwrap();
-    storage.store_article("misc", &msg).await.unwrap();
+    storage.store_article(&msg).await.unwrap();
     cleanup_expired_articles(&*storage, &cfg).await.unwrap();
     assert!(
         storage

--- a/tests/integration/storage.rs
+++ b/tests/integration/storage.rs
@@ -6,10 +6,9 @@ use renews::{
 #[tokio::test]
 async fn store_and_retrieve_article() {
     let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
-    let text = "Message-ID: <1@test>\r\nSubject: Hello\r\n\r\nBody";
+    let text = "Message-ID: <1@test>\r\nNewsgroups: group.test\r\nSubject: Hello\r\n\r\nBody";
     let (_, msg) = parse_message(text).unwrap();
-    let n = storage.store_article("group.test", &msg).await.unwrap();
-    assert_eq!(n, 1);
+    storage.store_article(&msg).await.unwrap();
     let fetched = storage
         .get_article_by_number("group.test", 1)
         .await
@@ -28,11 +27,57 @@ async fn store_and_retrieve_article() {
 #[tokio::test]
 async fn numbering_is_per_group() {
     let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
-    let (_, msg1) = parse_message("Message-ID: <1@test>\r\n\r\nA").unwrap();
-    let (_, msg2) = parse_message("Message-ID: <2@test>\r\n\r\nB").unwrap();
-    assert_eq!(storage.store_article("g1", &msg1).await.unwrap(), 1);
-    assert_eq!(storage.store_article("g1", &msg2).await.unwrap(), 2);
-    assert_eq!(storage.store_article("g2", &msg1).await.unwrap(), 1);
+    let (_, msg1) = parse_message("Message-ID: <1@test>\r\nNewsgroups: g1,g2\r\n\r\nA").unwrap();
+    let (_, msg2) = parse_message("Message-ID: <2@test>\r\nNewsgroups: g1\r\n\r\nB").unwrap();
+
+    // Store articles and verify numbering through retrieval
+    storage.store_article(&msg1).await.unwrap();
+    storage.store_article(&msg2).await.unwrap();
+
+    // Verify numbering is per group
+    assert!(
+        storage
+            .get_article_by_number("g1", 1)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        storage
+            .get_article_by_number("g1", 2)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        storage
+            .get_article_by_number("g2", 1)
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    // Verify msg1 is at position 1 in both groups
+    let g1_msg1 = storage
+        .get_article_by_number("g1", 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let g2_msg1 = storage
+        .get_article_by_number("g2", 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(g1_msg1.body, "A");
+    assert_eq!(g2_msg1.body, "A");
+
+    // Verify msg2 is at position 2 in g1
+    let g1_msg2 = storage
+        .get_article_by_number("g1", 2)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(g1_msg2.body, "B");
 }
 
 #[tokio::test]
@@ -58,9 +103,8 @@ async fn purge_old_articles() {
     let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
     storage.add_group("g1", false).await.unwrap();
     storage.add_group("g2", false).await.unwrap();
-    let (_, msg) = parse_message("Message-ID: <1@test>\r\n\r\nB").unwrap();
-    storage.store_article("g1", &msg).await.unwrap();
-    storage.store_article("g2", &msg).await.unwrap();
+    let (_, msg) = parse_message("Message-ID: <1@test>\r\nNewsgroups: g1,g2\r\n\r\nB").unwrap();
+    storage.store_article(&msg).await.unwrap();
 
     sleep(StdDuration::from_secs(1)).await;
     storage.purge_group_before("g1", Utc::now()).await.unwrap();
@@ -89,4 +133,133 @@ async fn purge_old_articles() {
             .unwrap()
             .is_none()
     );
+}
+
+#[tokio::test]
+async fn store_article_in_multiple_groups() {
+    let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
+    storage.add_group("group1", false).await.unwrap();
+    storage.add_group("group2", false).await.unwrap();
+    storage.add_group("group3", false).await.unwrap();
+
+    // Create an article with multiple newsgroups
+    let text = "Message-ID: <multi@test>\r\nNewsgroups: group1,group2,group3\r\nSubject: Multi\r\n\r\nBody";
+    let (_, msg) = parse_message(text).unwrap();
+
+    // Store the article - it should be automatically stored in all groups
+    storage.store_article(&msg).await.unwrap();
+
+    // Verify the article is in all three groups
+    let article1 = storage
+        .get_article_by_number("group1", 1)
+        .await
+        .unwrap()
+        .expect("article in group1");
+    let article2 = storage
+        .get_article_by_number("group2", 1)
+        .await
+        .unwrap()
+        .expect("article in group2");
+    let article3 = storage
+        .get_article_by_number("group3", 1)
+        .await
+        .unwrap()
+        .expect("article in group3");
+
+    assert_eq!(article1.body, "Body");
+    assert_eq!(article2.body, "Body");
+    assert_eq!(article3.body, "Body");
+
+    // Verify they're the same message by checking Message-ID
+    let msg_id1 = article1
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Message-ID"))
+        .unwrap()
+        .1
+        .clone();
+    let msg_id2 = article2
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Message-ID"))
+        .unwrap()
+        .1
+        .clone();
+    let msg_id3 = article3
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Message-ID"))
+        .unwrap()
+        .1
+        .clone();
+
+    assert_eq!(msg_id1, "<multi@test>");
+    assert_eq!(msg_id2, "<multi@test>");
+    assert_eq!(msg_id3, "<multi@test>");
+}
+
+#[tokio::test]
+async fn store_article_without_newsgroups_header() {
+    let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
+    storage.add_group("test", false).await.unwrap();
+
+    // Create an article without Newsgroups header
+    let text = "Message-ID: <no-groups@test>\r\nSubject: No Groups\r\n\r\nBody";
+    let (_, msg) = parse_message(text).unwrap();
+
+    // Store the article - should succeed but not be in any group
+    storage.store_article(&msg).await.unwrap();
+
+    // Verify the article is not retrievable by group (since it wasn't posted to any)
+    let article = storage.get_article_by_number("test", 1).await.unwrap();
+    assert!(article.is_none());
+
+    // But should be retrievable by message ID
+    let article = storage.get_article_by_id("<no-groups@test>").await.unwrap();
+    assert!(article.is_some());
+}
+
+#[tokio::test]
+async fn store_article_multiple_groups_comma_separated() {
+    let storage = SqliteStorage::new("sqlite::memory:").await.expect("init");
+    storage.add_group("group1", false).await.unwrap();
+    storage.add_group("group2", false).await.unwrap();
+    storage.add_group("group3", false).await.unwrap();
+
+    // Create an article with multiple newsgroups in a single header (comma-separated)
+    let text = "Message-ID: <multi@test>\r\nNewsgroups: group1,group2,group3\r\nSubject: Multi-post\r\n\r\nBody content";
+    let (_, msg) = parse_message(text).unwrap();
+
+    // Store the article - it should be automatically stored in all groups
+    storage.store_article(&msg).await.unwrap();
+
+    // Verify the article is in all three groups at position 1
+    for group in ["group1", "group2", "group3"] {
+        let article = storage
+            .get_article_by_number(group, 1)
+            .await
+            .unwrap()
+            .expect(&format!("article in {}", group));
+        assert_eq!(article.body, "Body content");
+
+        // Verify the Message-ID is consistent
+        let msg_id = article
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("Message-ID"))
+            .unwrap()
+            .1
+            .clone();
+        assert_eq!(msg_id, "<multi@test>");
+
+        // Verify the Newsgroups header contains all groups
+        let newsgroups = article
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("Newsgroups"))
+            .unwrap()
+            .1
+            .clone();
+        assert_eq!(newsgroups, "group1,group2,group3");
+    }
 }


### PR DESCRIPTION
- Updated `store_article` method in `SqliteStorage` to extract newsgroups from article headers and store the article in all relevant groups.
- Modified tests to ensure articles are stored correctly in multiple groups and to validate retrieval by group and message ID.
- Adjusted existing tests to include Newsgroups header in message parsing.
- Added new tests for storing articles without Newsgroups header and for handling multiple groups in a single header.