### PR TITLE
Centralize peer scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ flume = "0.11"
 tokio-tungstenite = { version = "0.21", optional = true }
 futures-util = { version = "0.3", optional = true }
 tokio-cron-scheduler = "0.13"
+uuid = { version = "1", features = ["v4"] }
 
 [features]
 websocket = ["tokio-tungstenite", "futures-util"]

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ following keys are recognised:
   `sqlite:///var/renews/auth.db` when unset.
 - `peer_db_path` - connection string for the peer state database. Defaults to
   `sqlite:///var/renews/peers.db`.
-- `peer_sync_secs` - default seconds between synchronizing with peers.
+- `peer_sync_schedule` - default cron schedule for synchronizing with peers.
 - `idle_timeout_secs` - idle timeout in seconds for client connections. Defaults to 600 (10 minutes).
-- `peers` - list of peer entries with `sitename`, optional `sync_interval_secs` and `patterns` controlling which groups are exchanged. The `sitename` may include credentials in the form `user:pass@host:port` which are used for `AUTHINFO` when connecting.
+- `peers` - list of peer entries with `sitename`, optional `sync_schedule` and `patterns` controlling which groups are exchanged. The `sitename` may include credentials in the form `user:pass@host:port` which are used for `AUTHINFO` when connecting.
 - `tls_addr` - optional listen address for NNTP over TLS. Omitting the host
   portion listens on all interfaces.
 - `tls_cert` - path to the TLS certificate in PEM format.
@@ -137,7 +137,7 @@ site_name = "example.com"
 db_path = "sqlite:///var/renews/news.db"
 auth_db_path = "sqlite:///var/renews/auth.db"
 peer_db_path = "sqlite:///var/renews/peers.db"
-peer_sync_secs = 3600
+peer_sync_schedule = "0 0 * * * *"
 idle_timeout_secs = 600
 tls_addr = ":563"
 tls_cert = "cert.pem"
@@ -158,7 +158,7 @@ max_article_bytes = "2M"
 [[peers]]
 sitename = "peeruser:peerpass@peer.example.com"
 patterns = ["*"]
-sync_interval_secs = 3600
+sync_schedule = "0 0 * * * *"
 ```
 
 `tls_addr`, `tls_cert` and `tls_key` must all be set for TLS support to be

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Runtime configuration management:
 
 ### Peer Synchronization (`src/peers.rs`)
 Distributed newsgroup synchronization:
-- Configurable sync intervals
+- Configurable cron schedules
 - Wildcard pattern matching for group selection
 - Incremental article transfer
 - Connection pooling and retry logic
@@ -106,7 +106,7 @@ handlers --> config : Group settings
 5. **Distribution** - Queue for peer synchronization if applicable
 
 ### Peer Synchronization Flow
-1. **Schedule Check** - Timer-based sync interval triggers
+1. **Schedule Check** - Cron-based schedule triggers
 2. **Group Enumeration** - List groups matching peer patterns
 3. **Incremental Sync** - Fetch articles since last sync timestamp
 4. **Transfer** - Use IHAVE/CHECK/TAKETHIS for efficient transfer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,12 +61,12 @@ max_article_bytes = "10M"       # Larger files allowed
 [[peers]]
 sitename = "user:pass@peer1.example.com:119"
 patterns = ["comp.*", "misc.*"] # Only sync these hierarchies
-sync_interval_secs = 1800       # Sync every 30 minutes
+sync_schedule = "0 */30 * * * *"       # Sync every 30 minutes
 
 [[peers]]
 sitename = "peer2.example.com"  # No authentication required
 patterns = ["*"]                # Sync all groups
-sync_interval_secs = 7200       # Sync every 2 hours
+sync_schedule = "0 0 */2 * * *"       # Sync every 2 hours
 ```
 
 ## Configuration Sections
@@ -152,7 +152,7 @@ Configure peer servers for article distribution:
 [[peers]]
 sitename = "news.example.com:119"    # Hostname and port
 patterns = ["*"]                     # Groups to sync (wildmat)
-sync_interval_secs = 3600           # Override default interval
+sync_schedule = "0 0 * * * *"           # Override default schedule
 
 [[peers]]
 sitename = "user:pass@secure.example.com:563"  # With credentials


### PR DESCRIPTION
## Summary
- use a single `JobScheduler` for all peers
- expose `build_peer_job` for creating peer sync jobs
- update tests for new scheduling approach
- document cron-based peer scheduling

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release`


------
https://chatgpt.com/codex/tasks/task_e_686fda2f272c8326bc0e9acd9ab5e71a