### PR TITLE
Add smallvec for improved memory efficiency in headers and streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "serial_test",
  "sha1",
  "sha2",
+ "smallvec",
  "sqlx",
  "tempfile",
  "tokio",
@@ -2423,6 +2424,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tokio-cron-scheduler = "0.13"
 uuid = { version = "1.17", features = ["v4"] }
 async-stream = "0.3"
 futures-core = "0.3"
+smallvec = { version = "1.13", features = ["serde"] }
 
 [features]
 websocket = ["tokio-tungstenite"]

--- a/examples/custom_filters.rs
+++ b/examples/custom_filters.rs
@@ -8,6 +8,7 @@ use renews::auth::DynAuth;
 use renews::config::Config;
 use renews::filters::{ArticleFilter, FilterChain};
 use renews::storage::DynStorage;
+use smallvec::smallvec;
 use std::error::Error;
 
 /// Example custom filter that blocks articles with certain words in the subject
@@ -121,7 +122,7 @@ pub async fn example_usage() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Example article that should fail profanity filter
     let bad_article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "user@example.com".to_string()),
             ("Subject".to_string(), "This is spam content".to_string()),
             ("Newsgroups".to_string(), "alt.test".to_string()),
@@ -140,7 +141,7 @@ pub async fn example_usage() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Example article that should pass
     let good_article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "user@example.com".to_string()),
             ("Subject".to_string(), "This is a good article".to_string()),
             ("Newsgroups".to_string(), "alt.test".to_string()),

--- a/src/filters/groups.rs
+++ b/src/filters/groups.rs
@@ -8,6 +8,7 @@ use crate::auth::DynAuth;
 use crate::config::Config;
 use crate::storage::DynStorage;
 use futures_util::TryStreamExt;
+use smallvec::SmallVec;
 use std::error::Error;
 
 /// Filter that validates newsgroups exist in the server
@@ -24,7 +25,7 @@ impl ArticleFilter for GroupExistenceFilter {
         _size: u64,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         // Get newsgroups from the article
-        let newsgroups: Vec<String> = article
+        let newsgroups: SmallVec<[String; 4]> = article
             .headers
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case("Newsgroups"))
@@ -33,7 +34,7 @@ impl ArticleFilter for GroupExistenceFilter {
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
+                    .collect::<SmallVec<[String; 4]>>()
             })
             .unwrap_or_default();
 

--- a/src/filters/header.rs
+++ b/src/filters/header.rs
@@ -7,6 +7,7 @@ use crate::Message;
 use crate::auth::DynAuth;
 use crate::config::Config;
 use crate::storage::DynStorage;
+use smallvec::SmallVec;
 use std::error::Error;
 
 /// Filter that validates required article headers
@@ -31,7 +32,7 @@ impl ArticleFilter for HeaderFilter {
             .headers
             .iter()
             .any(|(k, _)| k.eq_ignore_ascii_case("Subject"));
-        let newsgroups: Vec<String> = article
+        let newsgroups: SmallVec<[String; 4]> = article
             .headers
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case("Newsgroups"))
@@ -40,7 +41,7 @@ impl ArticleFilter for HeaderFilter {
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
+                    .collect::<SmallVec<[String; 4]>>()
             })
             .unwrap_or_default();
 

--- a/src/storage/common.rs
+++ b/src/storage/common.rs
@@ -1,9 +1,10 @@
 use super::Message;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 /// Serializable wrapper for message headers.
 #[derive(Serialize, Deserialize)]
-pub struct Headers(pub Vec<(String, String)>);
+pub struct Headers(pub SmallVec<[(String, String); 8]>);
 
 /// Extract the Message-ID header from an article.
 ///

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1,10 +1,11 @@
 use super::{
-    Message, Storage, StringStreamResult, GroupTimeStreamResult, NumberStreamResult,
+    Message, Storage, StringStream, StringTimestampStream, U64Stream,
     common::{Headers, extract_message_id},
 };
 use async_stream::stream;
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use smallvec::SmallVec;
 use sqlx::{
     PgPool, Row,
     postgres::{PgConnectOptions, PgPoolOptions},
@@ -78,7 +79,7 @@ impl Storage for PostgresStorage {
         .await?;
 
         // Extract newsgroups from headers
-        let newsgroups: Vec<String> = article
+        let newsgroups: SmallVec<[String; 4]> = article
             .headers
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case("Newsgroups"))
@@ -87,7 +88,7 @@ impl Storage for PostgresStorage {
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
+                    .collect::<SmallVec<[String; 4]>>()
             })
             .unwrap_or_default();
 
@@ -208,9 +209,7 @@ impl Storage for PostgresStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn list_groups(
-        &self,
-    ) -> StringStreamResult<'_> {
+    fn list_groups(&self) -> StringStream<'_> {
         let pool = self.pool.clone();
         Box::pin(stream! {
             let mut rows = sqlx::query("SELECT name FROM groups ORDER BY name")
@@ -229,10 +228,7 @@ impl Storage for PostgresStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn list_groups_since(
-        &self,
-        since: chrono::DateTime<chrono::Utc>,
-    ) -> StringStreamResult<'_> {
+    fn list_groups_since(&self, since: chrono::DateTime<chrono::Utc>) -> StringStream<'_> {
         let pool = self.pool.clone();
         let timestamp = since.timestamp();
         Box::pin(stream! {
@@ -253,10 +249,7 @@ impl Storage for PostgresStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn list_groups_with_times(
-        &self,
-    ) -> GroupTimeStreamResult<'_>
-    {
+    fn list_groups_with_times(&self) -> StringTimestampStream<'_> {
         let pool = self.pool.clone();
         Box::pin(stream! {
             let mut rows = sqlx::query("SELECT name, created_at FROM groups ORDER BY name")
@@ -278,10 +271,7 @@ impl Storage for PostgresStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn list_article_numbers(
-        &self,
-        group: &str,
-    ) -> NumberStreamResult<'_> {
+    fn list_article_numbers(&self, group: &str) -> U64Stream<'_> {
         let pool = self.pool.clone();
         let group = group.to_string();
         Box::pin(stream! {
@@ -302,10 +292,7 @@ impl Storage for PostgresStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn list_article_ids(
-        &self,
-        group: &str,
-    ) -> StringStreamResult<'_> {
+    fn list_article_ids(&self, group: &str) -> StringStream<'_> {
         let pool = self.pool.clone();
         let group = group.to_string();
         Box::pin(stream! {
@@ -330,7 +317,7 @@ impl Storage for PostgresStorage {
         &self,
         group: &str,
         since: chrono::DateTime<chrono::Utc>,
-    ) -> StringStreamResult<'_> {
+    ) -> StringStream<'_> {
         let pool = self.pool.clone();
         let group = group.to_string();
         let timestamp = since.timestamp();

--- a/tests/pgp_discovery.rs
+++ b/tests/pgp_discovery.rs
@@ -5,6 +5,7 @@ use renews::{
     Message,
     auth::pgp_discovery::{DefaultPgpKeyDiscovery, PgpKeyDiscovery},
 };
+use smallvec::smallvec;
 
 #[tokio::test]
 async fn test_pgp_discovery_with_missing_key() {
@@ -13,7 +14,7 @@ async fn test_pgp_discovery_with_missing_key() {
 
     // Create a test message
     let msg = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "test@example.com".to_string()),
             ("Subject".to_string(), "Test message".to_string()),
         ],
@@ -88,13 +89,10 @@ async fn test_pgp_discovery_placeholder() {
 #[tokio::test]
 async fn test_canonical_text_generation() {
     let msg = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "test@example.com".to_string()),
             ("Subject".to_string(), "Test Subject".to_string()),
-            (
-                "Date".to_string(),
-                "Mon, 1 Jan 2024 12:00:00 +0000".to_string(),
-            ),
+            ("Date".to_string(), "Mon, 1 Jan 2024 12:00:00 +0000".to_string()),
         ],
         body: "Test message body".to_string(),
     };
@@ -142,7 +140,7 @@ async fn test_verify_pgp_with_discovery_fallback() {
     let auth = renews::auth::open("sqlite::memory:").await.unwrap();
 
     let msg = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "test@example.com".to_string()),
             ("Subject".to_string(), "Test".to_string()),
         ],

--- a/tests/unit/filters.rs
+++ b/tests/unit/filters.rs
@@ -3,6 +3,7 @@ use renews::filters::size::SizeFilter;
 use renews::filters::{ArticleFilter, FilterChain};
 use renews::{Message, config::Config};
 use std::sync::Arc;
+use smallvec::smallvec;
 
 #[tokio::test]
 async fn test_header_filter_valid() {
@@ -12,7 +13,7 @@ async fn test_header_filter_valid() {
     let cfg = create_test_config();
 
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "test@example.com".to_string()),
             ("Subject".to_string(), "Test Article".to_string()),
             ("Newsgroups".to_string(), "alt.test".to_string()),
@@ -32,7 +33,7 @@ async fn test_header_filter_missing_from() {
     let cfg = create_test_config();
 
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("Subject".to_string(), "Test Article".to_string()),
             ("Newsgroups".to_string(), "alt.test".to_string()),
         ],
@@ -53,7 +54,7 @@ async fn test_size_filter_within_limit() {
     cfg.default_max_article_bytes = Some(1000);
 
     let article = Message {
-        headers: vec![],
+        headers: smallvec![],
         body: "Test body".to_string(),
     };
 
@@ -70,7 +71,7 @@ async fn test_size_filter_exceeds_limit() {
     cfg.default_max_article_bytes = Some(1000);
 
     let article = Message {
-        headers: vec![],
+        headers: smallvec![],
         body: "Test body".to_string(),
     };
 
@@ -112,7 +113,7 @@ async fn test_comprehensive_validation_compatibility() {
     let cfg = create_test_config();
 
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".to_string(), "test@example.com".to_string()),
             ("Subject".to_string(), "Test Article".to_string()),
             ("Newsgroups".to_string(), "alt.test".to_string()),

--- a/tests/unit/storage_common.rs
+++ b/tests/unit/storage_common.rs
@@ -1,10 +1,11 @@
 use renews::Message;
 use renews::storage::common::{Headers, extract_message_id};
+use smallvec::smallvec;
 
 #[test]
 fn test_extract_message_id_present() {
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".into(), "test@example.com".into()),
             ("Message-ID".into(), "<test123@example.com>".into()),
             ("Subject".into(), "Test subject".into()),
@@ -19,7 +20,7 @@ fn test_extract_message_id_present() {
 #[test]
 fn test_extract_message_id_case_insensitive() {
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".into(), "test@example.com".into()),
             ("message-id".into(), "<test123@example.com>".into()),
             ("Subject".into(), "Test subject".into()),
@@ -34,7 +35,7 @@ fn test_extract_message_id_case_insensitive() {
 #[test]
 fn test_extract_message_id_missing() {
     let article = Message {
-        headers: vec![
+        headers: smallvec![
             ("From".into(), "test@example.com".into()),
             ("Subject".into(), "Test subject".into()),
         ],
@@ -48,7 +49,7 @@ fn test_extract_message_id_missing() {
 #[test]
 fn test_extract_message_id_empty_headers() {
     let article = Message {
-        headers: vec![],
+        headers: smallvec![],
         body: "Test body".into(),
     };
 
@@ -58,7 +59,7 @@ fn test_extract_message_id_empty_headers() {
 
 #[test]
 fn test_headers_serialization() {
-    let headers = Headers(vec![
+    let headers = Headers(smallvec![
         ("From".into(), "test@example.com".into()),
         ("Subject".into(), "Test subject".into()),
     ]);


### PR DESCRIPTION
Replace `Vec` with `SmallVec` in headers to enhance memory efficiency, particularly for fixed-size collections. This change optimizes memory usage in various components handling message headers.